### PR TITLE
Fix useToast listener leak

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent `useToast` from re-registering its listener on every render

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_685c0c7617fc832bb60d8a31a8dd61ae