### PR TITLE
Add Vitest and initial mobile hook test

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ npm run dev
 npm run build
 ```
 
+## 🧪 Testing
+
+```bash
+# Run unit tests
+npm test
+```
+
 ## 🧩 Dependencies
 
 - [Lovable](https://lovable.dev)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -79,5 +80,8 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"
+    ,
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.1.0"
   }
 }

--- a/src/hooks/__tests__/use-mobile.test.tsx
+++ b/src/hooks/__tests__/use-mobile.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import { useIsMobile } from '../use-mobile'
+
+function mockMatchMedia(width: number) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width })
+  window.matchMedia = vi.fn().mockImplementation(query => ({
+    matches: width < 768,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    onchange: null,
+    dispatchEvent: vi.fn()
+  })) as any
+}
+
+describe('useIsMobile', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns true for mobile width', async () => {
+    mockMatchMedia(500)
+    const { result } = renderHook(() => useIsMobile())
+    await waitFor(() => expect(result.current).toBe(true))
+  })
+
+  it('returns false for desktop width', async () => {
+    mockMatchMedia(1200)
+    const { result } = renderHook(() => useIsMobile())
+    await waitFor(() => expect(result.current).toBe(false))
+  })
+})


### PR DESCRIPTION
## Summary
- install testing packages
- add test script to package.json
- create `useIsMobile` hook test
- document how to run tests

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0f317bb8832bbc3f054de3fc2970