### PR TITLE
feat: add SLO uptime calculator project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,9 @@
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
@@ -86,6 +88,10 @@
         "vite": "^7.1.10",
         "vitest": "^3.2.4",
         "wait-on": "^9.0.3"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=11.0.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -2090,6 +2096,68 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+      "integrity": "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
@@ -2178,6 +2246,39 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
@@ -114,4 +116,3 @@
     "wait-on": "^9.0.3"
   }
 }
-

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -13,6 +13,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://dylanbochman.com/projects</loc>
+    <lastmod>2026-01-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://dylanbochman.com/blog/2026-01-11-shaving-minutes-off-deploys</loc>
     <lastmod>2026-01-11</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/components/projects/uptime-calculator/IncidentInput.tsx
+++ b/src/components/projects/uptime-calculator/IncidentInput.tsx
@@ -1,0 +1,41 @@
+import { Slider } from '@/components/ui/slider';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent } from '@/components/ui/card';
+
+interface IncidentInputProps {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+export function IncidentInput({ value, onChange }: IncidentInputProps) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="space-y-2">
+          <div className="flex justify-between">
+            <div>
+              <Label htmlFor="incidents" className="text-sm font-medium">
+                Expected incidents per month
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                How many incidents typically require response?
+              </p>
+            </div>
+            <span className="text-sm font-mono tabular-nums text-primary">
+              {value} {value === 1 ? 'incident' : 'incidents'}
+            </span>
+          </div>
+          <Slider
+            id="incidents"
+            value={[value]}
+            onValueChange={([v]) => onChange(v)}
+            min={0}
+            max={20}
+            step={1}
+            className="w-full"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/projects/uptime-calculator/ResponseTimeInputs.tsx
+++ b/src/components/projects/uptime-calculator/ResponseTimeInputs.tsx
@@ -1,0 +1,120 @@
+import { Slider } from '@/components/ui/slider';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Eye, EyeOff } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { ResponseProfile } from './calculations';
+import type { EnabledPhases } from './index';
+
+interface ResponseTimeInputsProps {
+  profile: ResponseProfile;
+  enabledPhases: EnabledPhases;
+  onChange: (field: keyof ResponseProfile, value: number) => void;
+  onToggle: (field: keyof ResponseProfile) => void;
+}
+
+interface InputConfig {
+  field: keyof ResponseProfile;
+  label: string;
+  description: string;
+  max: number;
+}
+
+const INPUT_CONFIG: InputConfig[] = [
+  {
+    field: 'alertLatencyMin',
+    label: 'Alert latency',
+    description: 'Condition true → alert fires',
+    max: 30,
+  },
+  {
+    field: 'acknowledgeMin',
+    label: 'Time to acknowledge',
+    description: 'Alert fires → you see it',
+    max: 30,
+  },
+  {
+    field: 'travelMin',
+    label: 'Time to computer',
+    description: 'Get to your workstation',
+    max: 60,
+  },
+  {
+    field: 'authMin',
+    label: 'Time to authenticate',
+    description: 'VPN, SSO, internal tools',
+    max: 20,
+  },
+  {
+    field: 'diagnoseMin',
+    label: 'Time to diagnose',
+    description: 'Investigate underlying cause(s)',
+    max: 60,
+  },
+  {
+    field: 'fixMin',
+    label: 'Time to fix',
+    description: 'Implement the fix',
+    max: 120,
+  },
+];
+
+export function ResponseTimeInputs({
+  profile,
+  enabledPhases,
+  onChange,
+  onToggle,
+}: ResponseTimeInputsProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-4">
+        <CardTitle className="text-base">Response Times (per incident)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {INPUT_CONFIG.map(({ field, label, description, max }) => {
+          const isEnabled = enabledPhases[field];
+          return (
+            <div key={field} className={`space-y-2 ${!isEnabled ? 'opacity-50' : ''}`}>
+              <div className="flex justify-between items-start">
+                <div className="flex items-start gap-2">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 shrink-0"
+                    onClick={() => onToggle(field)}
+                    aria-label={isEnabled ? `Exclude ${label} from calculation` : `Include ${label} in calculation`}
+                  >
+                    {isEnabled ? (
+                      <Eye className="h-4 w-4" />
+                    ) : (
+                      <EyeOff className="h-4 w-4" />
+                    )}
+                  </Button>
+                  <div>
+                    <Label htmlFor={field} className="text-sm font-medium">
+                      {label}
+                    </Label>
+                    <p className="text-xs text-muted-foreground">{description}</p>
+                  </div>
+                </div>
+                <span className="text-sm font-mono tabular-nums text-primary">
+                  {isEnabled ? `${profile[field]} min` : 'excluded'}
+                </span>
+              </div>
+              <Slider
+                id={field}
+                value={[profile[field]]}
+                onValueChange={([value]) => onChange(field, value)}
+                min={0}
+                max={max}
+                step={1}
+                className="w-full"
+                disabled={!isEnabled}
+              />
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/projects/uptime-calculator/ResultsPanel.tsx
+++ b/src/components/projects/uptime-calculator/ResultsPanel.tsx
@@ -1,0 +1,255 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { AlertTriangle } from 'lucide-react';
+import {
+  type AchievableSlaResult,
+  type CanMeetSlaResult,
+  formatDuration,
+  formatSla,
+} from './calculations';
+
+interface ResultsPanelProps {
+  mode: 'achievable' | 'target';
+  result: AchievableSlaResult | CanMeetSlaResult;
+  achievableResult?: AchievableSlaResult;
+}
+
+export function ResultsPanel({
+  mode,
+  result,
+  achievableResult,
+}: ResultsPanelProps) {
+  if (mode === 'achievable') {
+    return <AchievableResults result={result as AchievableSlaResult} />;
+  }
+  return (
+    <TargetResults
+      result={result as CanMeetSlaResult}
+      achievableResult={achievableResult!}
+    />
+  );
+}
+
+function AchievableResults({ result }: { result: AchievableSlaResult }) {
+  const overheadBeforeFix = result.responseOverheadPercent;
+
+  return (
+    <div className="space-y-4">
+      {/* Summary stats */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Per-incident MTTR
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-xl font-bold">
+              {formatDuration(result.mttrMinutes)}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Monthly downtime
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-xl font-bold">
+              {formatDuration(result.monthlyDowntimeMinutes)}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Yearly downtime
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-xl font-bold">
+              {formatDuration(result.monthlyDowntimeMinutes * 12)}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-primary/5 border-primary/20">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Maximum achievable SLA
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-xl font-bold text-primary">
+              {formatSla(result.maxAchievableSla)}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Budget breakdown */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Downtime Budget Breakdown</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {result.breakdown.map((phase) => (
+            <div key={phase.phase} className="space-y-1">
+              <div className="flex justify-between text-sm">
+                <span>{phase.label}</span>
+                <span className="font-mono tabular-nums">
+                  {formatDuration(phase.totalMinutes)}{' '}
+                  <span className="text-muted-foreground">
+                    ({phase.percentOfBudget.toFixed(1)}%)
+                  </span>
+                </span>
+              </div>
+              <Progress value={phase.percentOfBudget} className="h-2" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Insight */}
+      <Card className="bg-amber-500/10 border-amber-500/20">
+        <CardContent className="pt-6">
+          <div className="flex gap-3">
+            <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" />
+            <div>
+              <p className="font-medium text-sm">Response overhead insight</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                {overheadBeforeFix.toFixed(0)}% of your error budget goes to response
+                overhead (alert latency, acknowledge, travel, authenticate) before you even
+                start diagnosing.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function TargetResults({
+  result,
+  achievableResult,
+}: {
+  result: CanMeetSlaResult;
+  achievableResult: AchievableSlaResult;
+}) {
+  const canMeet = result.canMeet;
+
+  return (
+    <div className="space-y-4">
+      {/* Stats comparison */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Monthly budget
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-xl font-bold">
+              {formatDuration(result.monthlyBudgetMinutes)}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Your MTTR
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-xl font-bold">
+              {formatDuration(result.mttrMinutes)}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Budget allows
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-xl font-bold">
+              {!isFinite(result.allowedIncidents)
+                ? '∞'
+                : result.allowedIncidents < 1
+                  ? result.allowedIncidents.toFixed(2)
+                  : result.allowedIncidents.toFixed(1)}{' '}
+              <span className="text-sm font-normal text-muted-foreground">
+                incidents/mo
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Yearly budget
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-xl font-bold">
+              {formatDuration(result.monthlyBudgetMinutes * 12)}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Recommendations if not meeting */}
+      {!canMeet && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">To meet {formatSla(result.targetSla)}, you could:</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              <li className="flex items-start gap-2">
+                <span className="text-primary">•</span>
+                <span>
+                  Reduce expected incidents to{' '}
+                  <strong className="text-foreground">
+                    {result.allowedIncidents < 1
+                      ? '< 1'
+                      : `≤ ${Math.floor(result.allowedIncidents)}`}
+                  </strong>{' '}
+                  per month
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-primary">•</span>
+                <span>
+                  Reduce MTTR to{' '}
+                  <strong className="text-foreground">
+                    {formatDuration(result.monthlyBudgetMinutes / result.expectedIncidents)}
+                  </strong>{' '}
+                  per incident
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-primary">•</span>
+                <span>
+                  Target{' '}
+                  <strong className="text-foreground">
+                    {formatSla(achievableResult.maxAchievableSla)}
+                  </strong>{' '}
+                  SLA instead (achievable with current profile)
+                </span>
+              </li>
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/projects/uptime-calculator/SlaTargetInput.tsx
+++ b/src/components/projects/uptime-calculator/SlaTargetInput.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { Slider } from '@/components/ui/slider';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { COMMON_SLA_TARGETS } from './calculations';
+
+interface SlaTargetInputProps {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+const MIN_SLA = 90;
+const MAX_SLA = 99.999;
+
+export function SlaTargetInput({ value, onChange }: SlaTargetInputProps) {
+  const [inputValue, setInputValue] = useState(value.toString());
+
+  const handleQuickSelect = (slaValue: string) => {
+    if (slaValue === 'custom') return;
+    const newValue = parseFloat(slaValue);
+    onChange(newValue);
+    setInputValue(newValue.toString());
+  };
+
+  const handleSliderChange = (newValue: number) => {
+    onChange(newValue);
+    setInputValue(newValue.toString());
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    setInputValue(raw);
+
+    const parsed = parseFloat(raw);
+    if (!isNaN(parsed) && parsed >= MIN_SLA && parsed <= MAX_SLA) {
+      onChange(parsed);
+    }
+  };
+
+  const handleInputBlur = () => {
+    const parsed = parseFloat(inputValue);
+    if (isNaN(parsed) || parsed < MIN_SLA) {
+      setInputValue(MIN_SLA.toString());
+      onChange(MIN_SLA);
+    } else if (parsed > MAX_SLA) {
+      setInputValue(MAX_SLA.toString());
+      onChange(MAX_SLA);
+    } else {
+      setInputValue(parsed.toString());
+    }
+  };
+
+  // Check if current value matches a common target
+  const matchingTarget = COMMON_SLA_TARGETS.find((t) => t.value === value);
+
+  return (
+    <Card>
+      <CardContent className="pt-6 space-y-4">
+        <div className="flex items-center gap-4">
+          <Label htmlFor="sla-quick" className="whitespace-nowrap">
+            Target SLA:
+          </Label>
+          <Select
+            value={matchingTarget ? value.toString() : 'custom'}
+            onValueChange={handleQuickSelect}
+          >
+            <SelectTrigger id="sla-quick" className="w-48">
+              <SelectValue placeholder="Select SLA" />
+            </SelectTrigger>
+            <SelectContent>
+              {COMMON_SLA_TARGETS.map(({ value: v, label }) => (
+                <SelectItem key={v} value={v.toString()}>
+                  {label}
+                </SelectItem>
+              ))}
+              <SelectItem value="custom">Custom</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex justify-between items-center">
+            <Label htmlFor="sla-slider" className="text-sm font-medium">
+              Fine-tune target
+            </Label>
+            <div className="flex items-center gap-1">
+              <Input
+                type="text"
+                inputMode="decimal"
+                value={inputValue}
+                onChange={handleInputChange}
+                onBlur={handleInputBlur}
+                className="w-24 h-7 text-sm font-mono tabular-nums text-primary text-right pr-1"
+              />
+              <span className="text-sm text-primary">%</span>
+            </div>
+          </div>
+          <Slider
+            id="sla-slider"
+            value={[value]}
+            onValueChange={([v]) => handleSliderChange(v)}
+            min={MIN_SLA}
+            max={MAX_SLA}
+            step={0.001}
+            className="w-full"
+          />
+          <p className="text-xs text-muted-foreground">
+            Slide or type to adjust between {MIN_SLA}% and {MAX_SLA}%
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/projects/uptime-calculator/TargetSummary.tsx
+++ b/src/components/projects/uptime-calculator/TargetSummary.tsx
@@ -1,0 +1,92 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CheckCircle2, XCircle } from 'lucide-react';
+import {
+  type AchievableSlaResult,
+  type CanMeetSlaResult,
+  formatDuration,
+  formatSla,
+} from './calculations';
+
+interface TargetSummaryProps {
+  result: CanMeetSlaResult;
+  achievableResult: AchievableSlaResult;
+}
+
+export function TargetSummary({ result, achievableResult }: TargetSummaryProps) {
+  const canMeet = result.canMeet;
+
+  return (
+    <div className="space-y-4">
+      {/* Verdict */}
+      <Card
+        className={
+          canMeet
+            ? 'bg-green-500/10 border-green-500/20'
+            : 'bg-red-500/10 border-red-500/20'
+        }
+      >
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-3">
+            {canMeet ? (
+              <CheckCircle2 className="h-8 w-8 text-green-500" />
+            ) : (
+              <XCircle className="h-8 w-8 text-red-500" />
+            )}
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="text-xl font-bold">
+                  {canMeet ? 'LIKELY TO MEET' : 'UNLIKELY TO MEET'}
+                </span>
+                <Badge variant={canMeet ? 'default' : 'destructive'}>
+                  {formatSla(result.targetSla)}
+                </Badge>
+              </div>
+              <p className="text-sm text-muted-foreground mt-1">
+                {canMeet
+                  ? `You have ${formatDuration(result.surplusOrDeficitMinutes)} of buffer in your error budget.`
+                  : `You're ${formatDuration(Math.abs(result.surplusOrDeficitMinutes))} over your error budget.`}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Budget visualization */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Error Budget Usage</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm">
+              <span>Expected usage</span>
+              <span className="font-mono tabular-nums">
+                {Math.min(100, (achievableResult.monthlyDowntimeMinutes / result.monthlyBudgetMinutes) * 100).toFixed(0)}%
+              </span>
+            </div>
+            <div className="relative h-4 w-full rounded-full bg-secondary overflow-hidden">
+              <div
+                className={`h-full transition-all ${canMeet ? 'bg-primary' : 'bg-red-500'}`}
+                style={{
+                  width: `${Math.min(100, (achievableResult.monthlyDowntimeMinutes / result.monthlyBudgetMinutes) * 100)}%`,
+                }}
+              />
+              {!canMeet && (
+                <div className="absolute top-0 right-0 h-full bg-red-500/30 border-l-2 border-red-500 border-dashed"
+                  style={{
+                    width: `${Math.max(0, 100 - (result.monthlyBudgetMinutes / achievableResult.monthlyDowntimeMinutes) * 100)}%`
+                  }}
+                />
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Budget: {formatDuration(result.monthlyBudgetMinutes)} | Expected:{' '}
+              {formatDuration(achievableResult.monthlyDowntimeMinutes)}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/projects/uptime-calculator/calculations.ts
+++ b/src/components/projects/uptime-calculator/calculations.ts
@@ -1,0 +1,314 @@
+/**
+ * Response profile representing time spent in each incident phase
+ */
+export interface ResponseProfile {
+  alertLatencyMin: number;
+  acknowledgeMin: number;
+  travelMin: number;
+  authMin: number;
+  diagnoseMin: number;
+  fixMin: number;
+}
+
+/**
+ * Breakdown of downtime budget by phase
+ */
+export interface PhaseBreakdown {
+  phase: string;
+  label: string;
+  totalMinutes: number;
+  percentOfBudget: number;
+}
+
+/**
+ * Result of SLA calculation in "What can I achieve?" mode
+ */
+export interface AchievableSlaResult {
+  mttrMinutes: number;
+  monthlyDowntimeMinutes: number;
+  maxAchievableSla: number;
+  breakdown: PhaseBreakdown[];
+  responseOverheadPercent: number;
+}
+
+/**
+ * Result of SLA calculation in "Can I meet this?" mode
+ */
+export interface CanMeetSlaResult {
+  targetSla: number;
+  monthlyBudgetMinutes: number;
+  mttrMinutes: number;
+  allowedIncidents: number;
+  expectedIncidents: number;
+  canMeet: boolean;
+  surplusOrDeficitMinutes: number;
+}
+
+// Constants
+export const MINUTES_PER_MONTH = 43200; // 30 days × 24 hours × 60 minutes
+export const MINUTES_PER_YEAR = 525600; // 365 days × 24 hours × 60 minutes
+
+/**
+ * Phase labels for display
+ */
+export const PHASE_LABELS: Record<keyof ResponseProfile, string> = {
+  alertLatencyMin: 'Alert latency',
+  acknowledgeMin: 'Acknowledge',
+  travelMin: 'Get to computer',
+  authMin: 'Authenticate',
+  diagnoseMin: 'Diagnose',
+  fixMin: 'Fix',
+};
+
+/**
+ * Calculate total MTTR (Mean Time To Resolve) per incident
+ */
+export function getMttrMinutes(profile: ResponseProfile): number {
+  return (
+    profile.alertLatencyMin +
+    profile.acknowledgeMin +
+    profile.travelMin +
+    profile.authMin +
+    profile.diagnoseMin +
+    profile.fixMin
+  );
+}
+
+/**
+ * Calculate monthly downtime given profile and incident count
+ */
+export function getMonthlyDowntimeMinutes(
+  profile: ResponseProfile,
+  incidentsPerMonth: number
+): number {
+  return getMttrMinutes(profile) * incidentsPerMonth;
+}
+
+/**
+ * Calculate max achievable SLA given profile and incident count
+ */
+export function calculateMaxSla(
+  profile: ResponseProfile,
+  incidentsPerMonth: number
+): number {
+  const downtimeMinutes = getMonthlyDowntimeMinutes(profile, incidentsPerMonth);
+  const uptimeMinutes = MINUTES_PER_MONTH - downtimeMinutes;
+  const sla = (uptimeMinutes / MINUTES_PER_MONTH) * 100;
+  return Math.max(0, Math.min(100, sla));
+}
+
+/**
+ * Calculate downtime budget in minutes for a given SLA percentage
+ */
+export function getDowntimeBudgetMinutes(slaPercent: number): number {
+  const downtimePercent = 100 - slaPercent;
+  return (downtimePercent / 100) * MINUTES_PER_MONTH;
+}
+
+/**
+ * Calculate how many incidents are allowed given target SLA and profile
+ */
+export function calculateAllowedIncidents(
+  profile: ResponseProfile,
+  targetSla: number
+): number {
+  const budgetMinutes = getDowntimeBudgetMinutes(targetSla);
+  const mttr = getMttrMinutes(profile);
+  if (mttr === 0) return Infinity;
+  return budgetMinutes / mttr;
+}
+
+/**
+ * Calculate budget breakdown by phase
+ */
+export function getBudgetBreakdown(
+  profile: ResponseProfile,
+  incidentsPerMonth: number
+): PhaseBreakdown[] {
+  const totalDowntime = getMonthlyDowntimeMinutes(profile, incidentsPerMonth);
+
+  const phases: { key: keyof ResponseProfile; label: string }[] = [
+    { key: 'alertLatencyMin', label: 'Alert latency' },
+    { key: 'acknowledgeMin', label: 'Acknowledge' },
+    { key: 'travelMin', label: 'Get to computer' },
+    { key: 'authMin', label: 'Authenticate' },
+    { key: 'diagnoseMin', label: 'Diagnose' },
+    { key: 'fixMin', label: 'Fix' },
+  ];
+
+  return phases.map(({ key, label }) => {
+    const phaseMinutes = profile[key] * incidentsPerMonth;
+    return {
+      phase: key,
+      label,
+      totalMinutes: phaseMinutes,
+      percentOfBudget: totalDowntime > 0 ? (phaseMinutes / totalDowntime) * 100 : 0,
+    };
+  });
+}
+
+/**
+ * Calculate response overhead percentage (time before fix begins)
+ */
+export function getResponseOverheadPercent(profile: ResponseProfile): number {
+  const mttr = getMttrMinutes(profile);
+  if (mttr === 0) return 0;
+
+  const overhead =
+    profile.alertLatencyMin + profile.acknowledgeMin + profile.travelMin + profile.authMin;
+  return (overhead / mttr) * 100;
+}
+
+/**
+ * Full calculation for "What SLA can I achieve?" mode
+ */
+export function calculateAchievableSla(
+  profile: ResponseProfile,
+  incidentsPerMonth: number
+): AchievableSlaResult {
+  return {
+    mttrMinutes: getMttrMinutes(profile),
+    monthlyDowntimeMinutes: getMonthlyDowntimeMinutes(profile, incidentsPerMonth),
+    maxAchievableSla: calculateMaxSla(profile, incidentsPerMonth),
+    breakdown: getBudgetBreakdown(profile, incidentsPerMonth),
+    responseOverheadPercent: getResponseOverheadPercent(profile),
+  };
+}
+
+/**
+ * Full calculation for "Can I meet this SLA?" mode
+ */
+export function calculateCanMeetSla(
+  profile: ResponseProfile,
+  targetSla: number,
+  expectedIncidents: number
+): CanMeetSlaResult {
+  const mttr = getMttrMinutes(profile);
+  const budgetMinutes = getDowntimeBudgetMinutes(targetSla);
+  const allowedIncidents = calculateAllowedIncidents(profile, targetSla);
+  const expectedDowntime = mttr * expectedIncidents;
+  const canMeet = expectedDowntime <= budgetMinutes;
+
+  return {
+    targetSla,
+    monthlyBudgetMinutes: budgetMinutes,
+    mttrMinutes: mttr,
+    allowedIncidents,
+    expectedIncidents,
+    canMeet,
+    surplusOrDeficitMinutes: budgetMinutes - expectedDowntime,
+  };
+}
+
+/**
+ * Format minutes into human-readable duration
+ */
+export function formatDuration(minutes: number): string {
+  if (minutes < 1) {
+    const seconds = Math.round(minutes * 60);
+    return `${seconds}s`;
+  }
+  if (minutes < 60) {
+    return `${Math.round(minutes)}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const mins = Math.round(minutes % 60);
+  if (hours < 24) {
+    return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
+}
+
+/**
+ * Format SLA percentage with appropriate precision
+ */
+export function formatSla(sla: number): string {
+  if (sla >= 99.99) {
+    return sla.toFixed(3) + '%';
+  }
+  if (sla >= 99) {
+    return sla.toFixed(2) + '%';
+  }
+  return sla.toFixed(1) + '%';
+}
+
+/**
+ * Default response profile values
+ */
+export const DEFAULT_PROFILE: ResponseProfile = {
+  alertLatencyMin: 5,
+  acknowledgeMin: 5,
+  travelMin: 2,
+  authMin: 3,
+  diagnoseMin: 15,
+  fixMin: 20,
+};
+
+/**
+ * Preset response profiles
+ */
+export const PRESETS: Record<string, { label: string; profile: ResponseProfile }> = {
+  'incident-commander': {
+    label: 'Incident Commander',
+    profile: {
+      alertLatencyMin: 2,
+      acknowledgeMin: 2,
+      travelMin: 0,
+      authMin: 1,
+      diagnoseMin: 10,
+      fixMin: 15,
+    },
+  },
+  'on-call-engineer': {
+    label: 'On-Call Working Hours',
+    profile: {
+      alertLatencyMin: 5,
+      acknowledgeMin: 5,
+      travelMin: 2,
+      authMin: 3,
+      diagnoseMin: 15,
+      fixMin: 20,
+    },
+  },
+  'after-hours': {
+    label: 'On-Call After Hours / Weekend',
+    profile: {
+      alertLatencyMin: 5,
+      acknowledgeMin: 10,
+      travelMin: 30,
+      authMin: 5,
+      diagnoseMin: 15,
+      fixMin: 20,
+    },
+  },
+};
+
+/**
+ * Common SLA targets for quick selection
+ */
+export const COMMON_SLA_TARGETS = [
+  { value: 99, label: '99% (two nines)' },
+  { value: 99.5, label: '99.5%' },
+  { value: 99.9, label: '99.9% (three nines)' },
+  { value: 99.95, label: '99.95%' },
+  { value: 99.99, label: '99.99% (four nines)' },
+];
+
+/**
+ * Get effective profile with disabled phases zeroed out
+ */
+export function getEffectiveProfile(
+  profile: ResponseProfile,
+  enabledPhases: Record<keyof ResponseProfile, boolean>
+): ResponseProfile {
+  return {
+    alertLatencyMin: enabledPhases.alertLatencyMin ? profile.alertLatencyMin : 0,
+    acknowledgeMin: enabledPhases.acknowledgeMin ? profile.acknowledgeMin : 0,
+    travelMin: enabledPhases.travelMin ? profile.travelMin : 0,
+    authMin: enabledPhases.authMin ? profile.authMin : 0,
+    diagnoseMin: enabledPhases.diagnoseMin ? profile.diagnoseMin : 0,
+    fixMin: enabledPhases.fixMin ? profile.fixMin : 0,
+  };
+}

--- a/src/components/projects/uptime-calculator/index.tsx
+++ b/src/components/projects/uptime-calculator/index.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { ResponseTimeInputs } from './ResponseTimeInputs';
+import { IncidentInput } from './IncidentInput';
+import { SlaTargetInput } from './SlaTargetInput';
+import { ResultsPanel } from './ResultsPanel';
+import { TargetSummary } from './TargetSummary';
+import {
+  type ResponseProfile,
+  DEFAULT_PROFILE,
+  PRESETS,
+  calculateAchievableSla,
+  calculateCanMeetSla,
+  getEffectiveProfile,
+} from './calculations';
+
+export type CalculationMode = 'achievable' | 'target';
+export type EnabledPhases = Record<keyof ResponseProfile, boolean>;
+
+const DEFAULT_ENABLED: EnabledPhases = {
+  alertLatencyMin: true,
+  acknowledgeMin: true,
+  travelMin: true,
+  authMin: true,
+  diagnoseMin: true,
+  fixMin: true,
+};
+
+export default function UptimeCalculator() {
+  const [mode, setMode] = useState<CalculationMode>('achievable');
+  const [profile, setProfile] = useState<ResponseProfile>(DEFAULT_PROFILE);
+  const [enabledPhases, setEnabledPhases] = useState<EnabledPhases>(DEFAULT_ENABLED);
+  const [incidentsPerMonth, setIncidentsPerMonth] = useState(4);
+  const [targetSla, setTargetSla] = useState(99.9);
+  const [selectedPreset, setSelectedPreset] = useState<string>('');
+
+  const handlePresetChange = (presetKey: string) => {
+    setSelectedPreset(presetKey);
+    if (presetKey && PRESETS[presetKey]) {
+      setProfile(PRESETS[presetKey].profile);
+    }
+  };
+
+  const handleProfileChange = (field: keyof ResponseProfile, value: number) => {
+    setProfile((prev) => ({ ...prev, [field]: value }));
+    setSelectedPreset(''); // Clear preset when manually adjusting
+  };
+
+  const handleTogglePhase = (field: keyof ResponseProfile) => {
+    setEnabledPhases((prev) => ({ ...prev, [field]: !prev[field] }));
+  };
+
+  // Get effective profile with disabled phases zeroed out
+  const effectiveProfile = getEffectiveProfile(profile, enabledPhases);
+
+  // Calculate results based on mode
+  const achievableResult = calculateAchievableSla(effectiveProfile, incidentsPerMonth);
+  const targetResult = calculateCanMeetSla(effectiveProfile, targetSla, incidentsPerMonth);
+
+  return (
+    <div className="space-y-6">
+      <Tabs value={mode} onValueChange={(v) => setMode(v as CalculationMode)}>
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="achievable" className="text-xs sm:text-sm">
+            <span className="hidden sm:inline">What can I achieve?</span>
+            <span className="sm:hidden">Achievable SLA</span>
+          </TabsTrigger>
+          <TabsTrigger value="target" className="text-xs sm:text-sm">
+            <span className="hidden sm:inline">Can I meet this SLA?</span>
+            <span className="sm:hidden">Meet Target?</span>
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Target mode: SLA input and summary at top */}
+        <TabsContent value="target" className="mt-6 space-y-6">
+          <SlaTargetInput value={targetSla} onChange={setTargetSla} />
+          <TargetSummary result={targetResult} achievableResult={achievableResult} />
+        </TabsContent>
+
+        <div className="mt-6 space-y-6">
+          {/* Preset selector */}
+          <div className="flex items-center gap-4">
+            <Label htmlFor="preset" className="whitespace-nowrap">
+              Response profile:
+            </Label>
+            <Select value={selectedPreset} onValueChange={handlePresetChange}>
+              <SelectTrigger id="preset" className="w-48">
+                <SelectValue placeholder="Custom" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="custom">Custom</SelectItem>
+                {Object.entries(PRESETS).map(([key, { label }]) => (
+                  <SelectItem key={key} value={key}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Response time inputs */}
+          <ResponseTimeInputs
+            profile={profile}
+            enabledPhases={enabledPhases}
+            onChange={handleProfileChange}
+            onToggle={handleTogglePhase}
+          />
+
+          {/* Incidents per month */}
+          <IncidentInput
+            value={incidentsPerMonth}
+            onChange={setIncidentsPerMonth}
+          />
+        </div>
+
+        {/* Results */}
+        <div className="mt-6">
+          <TabsContent value="achievable" className="mt-0">
+            <ResultsPanel mode="achievable" result={achievableResult} />
+          </TabsContent>
+          <TabsContent value="target" className="mt-0">
+            <ResultsPanel
+              mode="target"
+              result={targetResult}
+              achievableResult={achievableResult}
+            />
+          </TabsContent>
+        </div>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -2,8 +2,8 @@ import { lazy } from 'react';
 import type { ProjectDefinition, ProjectMeta } from '@/types/project';
 
 // Lazy load project components for code splitting
-const PlaceholderProject = lazy(
-  () => import('@/components/projects/PlaceholderProject')
+const UptimeCalculator = lazy(
+  () => import('@/components/projects/uptime-calculator')
 );
 
 /**
@@ -12,15 +12,15 @@ const PlaceholderProject = lazy(
  */
 export const projectRegistry: ProjectDefinition[] = [
   {
-    slug: 'placeholder',
-    title: 'Placeholder Project',
+    slug: 'uptime-calculator',
+    title: 'SLO Uptime Calculator',
     description:
-      'A placeholder project for testing the projects infrastructure. This will be replaced with real projects.',
-    tags: ['Testing', 'Infrastructure'],
-    icon: 'Box',
-    status: 'experimental',
+      'Calculate realistic SLOs based on your incident response times. See how much of your error budget goes to response overhead before you even start fixing things.',
+    tags: ['SRE', 'Calculator', 'SLA'],
+    icon: 'Calculator',
+    status: 'active',
     createdAt: '2025-01-12',
-    component: PlaceholderProject,
+    component: UptimeCalculator,
   },
 ];
 


### PR DESCRIPTION
## Summary
Interactive calculator that helps engineers understand achievable SLAs based on their incident response times. Replaces the placeholder project from the projects infrastructure PR.

## The Journey
- Started with the project infrastructure from PR #88
- Built out calculation logic for MTTR and SLA percentages
- Added two modes: "What SLA can I achieve?" and "Can I meet this SLA target?"
- Iterated on UX: moved target SLA and verdict to top of page for immediate feedback
- Added visibility toggles to let users exclude response phases from calculations
- Made SLA input directly editable (not just slider)
- Refined response overhead insight to focus on pre-diagnosis overhead

## Changes
- `src/components/projects/uptime-calculator/` - New calculator component
  - `calculations.ts` - Pure calculation functions for MTTR, SLA, budgets
  - `index.tsx` - Main component with state management
  - `ResponseTimeInputs.tsx` - Sliders with visibility toggles
  - `SlaTargetInput.tsx` - Editable SLA target with slider sync
  - `TargetSummary.tsx` - Verdict and budget usage visualization
  - `ResultsPanel.tsx` - Detailed results and recommendations
  - `IncidentInput.tsx` - Expected incidents per month
- `src/data/projects.ts` - Updated registry with uptime calculator
- `package.json` - Added @radix-ui/react-slider and @radix-ui/react-progress
- `public/sitemap.xml` - Added project routes

## Test Plan
- [ ] Navigate to `/projects` and verify the uptime calculator card appears
- [ ] Click through to `/projects/uptime-calculator`
- [ ] Test "What can I achieve?" mode with different response times
- [ ] Test "Can I meet this SLA?" mode with various targets
- [ ] Verify preset profiles load correct values
- [ ] Toggle visibility icons to exclude phases and verify calculations update
- [ ] Type directly in SLA percentage input and verify slider syncs
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)