### PR TITLE
fix: improve incident input mobile layout

### DIFF
--- a/src/components/projects/uptime-calculator/IncidentInput.tsx
+++ b/src/components/projects/uptime-calculator/IncidentInput.tsx
@@ -12,7 +12,7 @@ export function IncidentInput({ value, onChange }: IncidentInputProps) {
     <Card>
       <CardContent className="pt-6">
         <div className="space-y-2">
-          <div className="flex justify-between">
+          <div className="flex flex-col sm:flex-row sm:justify-between gap-1">
             <div>
               <Label htmlFor="incidents" className="text-sm font-medium">
                 Expected incidents per month
@@ -21,7 +21,7 @@ export function IncidentInput({ value, onChange }: IncidentInputProps) {
                 How many incidents typically require response?
               </p>
             </div>
-            <span className="text-sm font-mono tabular-nums text-primary">
+            <span className="text-sm font-mono tabular-nums text-primary shrink-0">
               {value} {value === 1 ? 'incident' : 'incidents'}
             </span>
           </div>


### PR DESCRIPTION
## Summary
Fixes cramped layout on mobile for the incident input component in the uptime calculator.

## Changes
- Stack label and value vertically on mobile (`flex-col`)
- Side-by-side layout on larger screens (`sm:flex-row sm:justify-between`)
- Added `shrink-0` to prevent value from wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)