### PR TITLE
feat(blog): When Your Roadmap Accepts Pull Requests

### DIFF
--- a/content/blog/2026-01-14-the-site-that-plans-itself.txt
+++ b/content/blog/2026-01-14-the-site-that-plans-itself.txt
@@ -9,7 +9,6 @@ tags:
   - AI
   - Open Source
 category: Meta
-draft: true
 ---
 
 We just merged a Kanban board into the site. That's not the interesting part—Kanban boards are commodity software. The interesting part is *what* we put on it: the roadmap for the site itself.


### PR DESCRIPTION
## Summary
Meta blog post about moving the roadmap into a public Kanban board and enabling visitor contributions via PRs.

## The Journey
- Started as "The Site That Plans Itself" but too similar to existing title
- Reworked to focus on collaboration/dialogue aspect
- Added direct GitHub links for discoverability

## Changes
- New blog post: `content/blog/2026-01-14-the-site-that-plans-itself.txt`

## Test Plan
- [ ] Post renders correctly at /blog/2026-01-14-the-site-that-plans-itself
- [ ] All links work (kanban board, GitHub files, PRs page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)