### PR TITLE
fix(a11y): improve project page accessibility scores

### DIFF
--- a/.claude/codex-reviews.md
+++ b/.claude/codex-reviews.md
@@ -55,3 +55,16 @@ Capturing feedback from Codex async code reviews to identify patterns and inform
   - Should sorting disable drag-and-drop (view-only) or reorder underlying data?
   - Should history reflect only committed moves (on drop)?
 - **Category**: architecture | edge cases
+
+---
+
+### 2026-01-14 - CI Failures Fix PR #99
+
+- **What it flagged**:
+  1. (Medium) Console error test ignores ALL 404s from own domain/localhost, masking real regressions (missing assets, broken routes, API calls). Should whitelist only known SPA fallback paths.
+  2. (Low) PR label linking matches `PR #88-92` and links to PR 88, which is misleading for ranges.
+- **Agreed?**: Yes - both valid
+- **Fix applied**:
+  1. Tightened 404 ignore logic: only ignore HTML document 404s (SPA fallback), not asset 404s (.js, .css, .json, images, etc.)
+  2. Changed regex from `/^PR #(\d+)/` to `/^PR #(\d+)$/` - only links single PRs, not ranges
+- **Category**: edge cases | UX

--- a/src/components/projects/kanban/KanbanCard.tsx
+++ b/src/components/projects/kanban/KanbanCard.tsx
@@ -2,9 +2,18 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Pencil, CheckSquare, FileText } from 'lucide-react';
+import { Pencil, CheckSquare, FileText, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { KanbanCard as KanbanCardType } from '@/types/kanban';
+
+const REPO_URL = 'https://github.com/Dbochman/personal-website';
+
+// Check if label is a single PR reference (not a range) and extract PR number
+function parsePrLabel(label: string): number | null {
+  // Only match single PRs like "PR #123", not ranges like "PR #88-92"
+  const match = label.match(/^PR #(\d+)$/);
+  return match ? parseInt(match[1], 10) : null;
+}
 
 interface KanbanCardProps {
   card: KanbanCardType;
@@ -63,11 +72,32 @@ export function KanbanCard({ card, onEdit, isDragOverlay = false }: KanbanCardPr
         )}
         {card.labels && card.labels.length > 0 && (
           <div className="flex flex-wrap gap-1 mt-2">
-            {card.labels.map((label) => (
-              <Badge key={label} variant="secondary" className="text-xs px-1.5 py-0">
-                {label}
-              </Badge>
-            ))}
+            {card.labels.map((label) => {
+              const prNumber = parsePrLabel(label);
+              if (prNumber) {
+                return (
+                  <a
+                    key={label}
+                    href={`${REPO_URL}/pull/${prNumber}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    className="inline-flex"
+                  >
+                    <Badge variant="secondary" className="text-xs px-1.5 py-0 hover:bg-primary/20 transition-colors cursor-pointer">
+                      {label}
+                      <ExternalLink className="w-2.5 h-2.5 ml-1 opacity-60" />
+                    </Badge>
+                  </a>
+                );
+              }
+              return (
+                <Badge key={label} variant="secondary" className="text-xs px-1.5 py-0">
+                  {label}
+                </Badge>
+              );
+            })}
           </div>
         )}
         {(card.checklist?.length || card.planFile) && (

--- a/src/components/projects/oncall-coverage/DailyHeatmap.tsx
+++ b/src/components/projects/oncall-coverage/DailyHeatmap.tsx
@@ -7,16 +7,16 @@ interface DailyHeatmapProps {
   dayIndex?: number; // 0=Sun, 1=Mon, etc. Default to Monday
 }
 
-// Colors for regions/timezones
+// Colors for regions/timezones (using darker shades for WCAG AA contrast with white text)
 const REGION_COLORS: Record<string, { bg: string; text: string }> = {
-  'Asia/Tokyo': { bg: 'bg-violet-400 dark:bg-violet-600', text: 'text-white' },
-  'Asia/Singapore': { bg: 'bg-violet-400 dark:bg-violet-600', text: 'text-white' },
-  'Asia/Shanghai': { bg: 'bg-violet-400 dark:bg-violet-600', text: 'text-white' },
-  'Europe/London': { bg: 'bg-rose-400 dark:bg-rose-600', text: 'text-white' },
-  'Europe/Paris': { bg: 'bg-rose-400 dark:bg-rose-600', text: 'text-white' },
-  'Europe/Berlin': { bg: 'bg-rose-400 dark:bg-rose-600', text: 'text-white' },
+  'Asia/Tokyo': { bg: 'bg-violet-600 dark:bg-violet-600', text: 'text-white' },
+  'Asia/Singapore': { bg: 'bg-violet-600 dark:bg-violet-600', text: 'text-white' },
+  'Asia/Shanghai': { bg: 'bg-violet-600 dark:bg-violet-600', text: 'text-white' },
+  'Europe/London': { bg: 'bg-rose-600 dark:bg-rose-600', text: 'text-white' },
+  'Europe/Paris': { bg: 'bg-rose-600 dark:bg-rose-600', text: 'text-white' },
+  'Europe/Berlin': { bg: 'bg-rose-600 dark:bg-rose-600', text: 'text-white' },
   'America/New_York': { bg: 'bg-emerald-700 dark:bg-emerald-600', text: 'text-white' },
-  'America/Los_Angeles': { bg: 'bg-sky-500 dark:bg-sky-600', text: 'text-white' },
+  'America/Los_Angeles': { bg: 'bg-sky-600 dark:bg-sky-600', text: 'text-white' },
   'America/Chicago': { bg: 'bg-emerald-700 dark:bg-emerald-600', text: 'text-white' },
 };
 
@@ -32,10 +32,10 @@ const TIMEZONE_LABELS: Record<string, string> = {
   'America/Chicago': 'US Central (CT)',
 };
 
-// Colors for shift types (single-site models)
+// Colors for shift types (single-site models) - using darker shades for WCAG AA contrast
 const SHIFT_COLORS: Record<string, { bg: string; text: string }> = {
-  'day': { bg: 'bg-amber-400 dark:bg-amber-500', text: 'text-white' },
-  'night': { bg: 'bg-indigo-500 dark:bg-indigo-600', text: 'text-white' },
+  'day': { bg: 'bg-amber-600 dark:bg-amber-600', text: 'text-white' },
+  'night': { bg: 'bg-indigo-600 dark:bg-indigo-600', text: 'text-white' },
 };
 
 // Helper to format hour with padding
@@ -201,7 +201,7 @@ export function DailyHeatmap({ coverage, team, dayIndex = 1 }: DailyHeatmapProps
 
   const renderTimeline = (blocks: CoverageBlock[], title: string) => (
     <div className="space-y-2">
-      <h4 className="text-sm font-medium text-muted-foreground">{title}</h4>
+      <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
       <div className="relative h-12 bg-zinc-200 dark:bg-zinc-700 rounded-lg overflow-hidden">
         {blocks.map((block, index) => {
           const widthPercent = ((block.endHour - block.startHour) / 24) * 100;

--- a/src/components/projects/oncall-coverage/Tradeoffs.tsx
+++ b/src/components/projects/oncall-coverage/Tradeoffs.tsx
@@ -16,9 +16,9 @@ export function Tradeoffs({ tradeoffs }: TradeoffsProps) {
         <div className="grid gap-4 sm:grid-cols-2">
           {/* Pros */}
           <div className="space-y-2">
-            <h4 className="text-xs font-medium text-green-600 dark:text-green-400 uppercase tracking-wide">
+            <h3 className="text-xs font-medium text-green-600 dark:text-green-400 uppercase tracking-wide">
               Advantages
-            </h4>
+            </h3>
             <ul className="space-y-1.5">
               {tradeoffs.pros.map((pro, index) => (
                 <li key={index} className="flex items-start gap-2 text-sm">
@@ -31,9 +31,9 @@ export function Tradeoffs({ tradeoffs }: TradeoffsProps) {
 
           {/* Cons */}
           <div className="space-y-2">
-            <h4 className="text-xs font-medium text-amber-600 dark:text-amber-400 uppercase tracking-wide">
+            <h3 className="text-xs font-medium text-amber-600 dark:text-amber-400 uppercase tracking-wide">
               Considerations
-            </h4>
+            </h3>
             <ul className="space-y-1.5">
               {tradeoffs.cons.map((con, index) => (
                 <li key={index} className="flex items-start gap-2 text-sm">

--- a/src/components/projects/oncall-coverage/WeeklyHeatmap.tsx
+++ b/src/components/projects/oncall-coverage/WeeklyHeatmap.tsx
@@ -6,16 +6,16 @@ interface WeeklyHeatmapProps {
   team: TeamMember[];
 }
 
-// Pastel colors for team members
+// Pastel colors for team members (strips use darker shades for WCAG AA contrast with white text)
 const MEMBER_COLORS = [
-  { bg: 'bg-emerald-200 dark:bg-emerald-800', strip: 'bg-emerald-400 dark:bg-emerald-600', text: 'text-emerald-800 dark:text-emerald-200' },
-  { bg: 'bg-rose-200 dark:bg-rose-800', strip: 'bg-rose-400 dark:bg-rose-600', text: 'text-rose-800 dark:text-rose-200' },
-  { bg: 'bg-violet-200 dark:bg-violet-800', strip: 'bg-violet-400 dark:bg-violet-600', text: 'text-violet-800 dark:text-violet-200' },
-  { bg: 'bg-amber-200 dark:bg-amber-800', strip: 'bg-amber-400 dark:bg-amber-600', text: 'text-amber-800 dark:text-amber-200' },
-  { bg: 'bg-sky-200 dark:bg-sky-800', strip: 'bg-sky-400 dark:bg-sky-600', text: 'text-sky-800 dark:text-sky-200' },
-  { bg: 'bg-pink-200 dark:bg-pink-800', strip: 'bg-pink-400 dark:bg-pink-600', text: 'text-pink-800 dark:text-pink-200' },
-  { bg: 'bg-teal-200 dark:bg-teal-800', strip: 'bg-teal-400 dark:bg-teal-600', text: 'text-teal-800 dark:text-teal-200' },
-  { bg: 'bg-orange-200 dark:bg-orange-800', strip: 'bg-orange-400 dark:bg-orange-600', text: 'text-orange-800 dark:text-orange-200' },
+  { bg: 'bg-emerald-200 dark:bg-emerald-800', strip: 'bg-emerald-600 dark:bg-emerald-600', text: 'text-emerald-800 dark:text-emerald-200' },
+  { bg: 'bg-rose-200 dark:bg-rose-800', strip: 'bg-rose-600 dark:bg-rose-600', text: 'text-rose-800 dark:text-rose-200' },
+  { bg: 'bg-violet-200 dark:bg-violet-800', strip: 'bg-violet-600 dark:bg-violet-600', text: 'text-violet-800 dark:text-violet-200' },
+  { bg: 'bg-amber-200 dark:bg-amber-800', strip: 'bg-amber-600 dark:bg-amber-600', text: 'text-amber-800 dark:text-amber-200' },
+  { bg: 'bg-sky-200 dark:bg-sky-800', strip: 'bg-sky-600 dark:bg-sky-600', text: 'text-sky-800 dark:text-sky-200' },
+  { bg: 'bg-pink-200 dark:bg-pink-800', strip: 'bg-pink-600 dark:bg-pink-600', text: 'text-pink-800 dark:text-pink-200' },
+  { bg: 'bg-teal-200 dark:bg-teal-800', strip: 'bg-teal-600 dark:bg-teal-600', text: 'text-teal-800 dark:text-teal-200' },
+  { bg: 'bg-orange-200 dark:bg-orange-800', strip: 'bg-orange-600 dark:bg-orange-600', text: 'text-orange-800 dark:text-orange-200' },
 ];
 
 const DAYS_FULL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];

--- a/src/components/projects/oncall-coverage/types.ts
+++ b/src/components/projects/oncall-coverage/types.ts
@@ -50,24 +50,24 @@ export interface CoverageModel {
 
 export const DAYS_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 
-// Region colors for team list - matches DailyHeatmap
+// Region colors for team list - using darker shades for WCAG AA contrast
 export const REGION_COLORS: Record<Region, { bg: string; text: string }> = {
   US: { bg: 'bg-emerald-700', text: 'text-emerald-700' },
-  EU: { bg: 'bg-rose-400', text: 'text-rose-400' },
-  APAC: { bg: 'bg-violet-400', text: 'text-violet-400' },
-  Single: { bg: 'bg-purple-500', text: 'text-purple-500' },
+  EU: { bg: 'bg-rose-600', text: 'text-rose-600' },
+  APAC: { bg: 'bg-violet-600', text: 'text-violet-600' },
+  Single: { bg: 'bg-purple-600', text: 'text-purple-600' },
 };
 
-// Member colors for rotation views (index-based, pastel)
+// Member colors for rotation views (index-based, pastel; strips use darker shades for WCAG AA contrast)
 export const MEMBER_COLORS = [
-  { bg: 'bg-emerald-200 dark:bg-emerald-800', strip: 'bg-emerald-400 dark:bg-emerald-600', text: 'text-emerald-800 dark:text-emerald-200' },
-  { bg: 'bg-rose-200 dark:bg-rose-800', strip: 'bg-rose-400 dark:bg-rose-600', text: 'text-rose-800 dark:text-rose-200' },
-  { bg: 'bg-violet-200 dark:bg-violet-800', strip: 'bg-violet-400 dark:bg-violet-600', text: 'text-violet-800 dark:text-violet-200' },
-  { bg: 'bg-amber-200 dark:bg-amber-800', strip: 'bg-amber-400 dark:bg-amber-600', text: 'text-amber-800 dark:text-amber-200' },
-  { bg: 'bg-sky-200 dark:bg-sky-800', strip: 'bg-sky-400 dark:bg-sky-600', text: 'text-sky-800 dark:text-sky-200' },
-  { bg: 'bg-pink-200 dark:bg-pink-800', strip: 'bg-pink-400 dark:bg-pink-600', text: 'text-pink-800 dark:text-pink-200' },
-  { bg: 'bg-teal-200 dark:bg-teal-800', strip: 'bg-teal-400 dark:bg-teal-600', text: 'text-teal-800 dark:text-teal-200' },
-  { bg: 'bg-orange-200 dark:bg-orange-800', strip: 'bg-orange-400 dark:bg-orange-600', text: 'text-orange-800 dark:text-orange-200' },
+  { bg: 'bg-emerald-200 dark:bg-emerald-800', strip: 'bg-emerald-600 dark:bg-emerald-600', text: 'text-emerald-800 dark:text-emerald-200' },
+  { bg: 'bg-rose-200 dark:bg-rose-800', strip: 'bg-rose-600 dark:bg-rose-600', text: 'text-rose-800 dark:text-rose-200' },
+  { bg: 'bg-violet-200 dark:bg-violet-800', strip: 'bg-violet-600 dark:bg-violet-600', text: 'text-violet-800 dark:text-violet-200' },
+  { bg: 'bg-amber-200 dark:bg-amber-800', strip: 'bg-amber-600 dark:bg-amber-600', text: 'text-amber-800 dark:text-amber-200' },
+  { bg: 'bg-sky-200 dark:bg-sky-800', strip: 'bg-sky-600 dark:bg-sky-600', text: 'text-sky-800 dark:text-sky-200' },
+  { bg: 'bg-pink-200 dark:bg-pink-800', strip: 'bg-pink-600 dark:bg-pink-600', text: 'text-pink-800 dark:text-pink-200' },
+  { bg: 'bg-teal-200 dark:bg-teal-800', strip: 'bg-teal-600 dark:bg-teal-600', text: 'text-teal-800 dark:text-teal-200' },
+  { bg: 'bg-orange-200 dark:bg-orange-800', strip: 'bg-orange-600 dark:bg-orange-600', text: 'text-orange-800 dark:text-orange-200' },
 ];
 
 // Timezone to label mapping

--- a/src/components/projects/statuspage-update/IncidentInputs.tsx
+++ b/src/components/projects/statuspage-update/IncidentInputs.tsx
@@ -49,7 +49,7 @@ export function IncidentInputs({
   return (
     <Card>
       <CardHeader className="pb-4">
-        <CardTitle className="text-base">Incident Details</CardTitle>
+        <CardTitle as="h2" className="text-base">Incident Details</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         {/* Service Preset */}

--- a/src/components/projects/statuspage-update/MessageOutput.tsx
+++ b/src/components/projects/statuspage-update/MessageOutput.tsx
@@ -30,7 +30,7 @@ export function MessageOutput({ title, message }: MessageOutputProps) {
   return (
     <Card>
       <CardHeader className="pb-4">
-        <CardTitle className="text-base">Generated Status Update</CardTitle>
+        <CardTitle as="h2" className="text-base">Generated Status Update</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         {/* Title */}

--- a/src/components/projects/uptime-calculator/ResultsPanel.tsx
+++ b/src/components/projects/uptime-calculator/ResultsPanel.tsx
@@ -159,7 +159,7 @@ function AchievableResults({ result }: { result: AchievableSlaResult }) {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle as="h2" className="text-sm font-medium text-muted-foreground">
               Per-incident MTTR
             </CardTitle>
           </CardHeader>
@@ -172,7 +172,7 @@ function AchievableResults({ result }: { result: AchievableSlaResult }) {
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle as="h2" className="text-sm font-medium text-muted-foreground">
               Monthly downtime
             </CardTitle>
           </CardHeader>
@@ -185,7 +185,7 @@ function AchievableResults({ result }: { result: AchievableSlaResult }) {
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle as="h2" className="text-sm font-medium text-muted-foreground">
               Yearly downtime
             </CardTitle>
           </CardHeader>
@@ -198,7 +198,7 @@ function AchievableResults({ result }: { result: AchievableSlaResult }) {
 
         <Card className="bg-primary/5 border-primary/20">
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle as="h2" className="text-sm font-medium text-muted-foreground">
               Maximum achievable SLA
             </CardTitle>
           </CardHeader>
@@ -277,7 +277,7 @@ function TargetResults({
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle as="h2" className="text-sm font-medium text-muted-foreground">
               Monthly budget
             </CardTitle>
           </CardHeader>
@@ -290,7 +290,7 @@ function TargetResults({
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle as="h2" className="text-sm font-medium text-muted-foreground">
               Your MTTR
             </CardTitle>
           </CardHeader>
@@ -303,7 +303,7 @@ function TargetResults({
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle as="h2" className="text-sm font-medium text-muted-foreground">
               Budget allows
             </CardTitle>
           </CardHeader>
@@ -323,7 +323,7 @@ function TargetResults({
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle as="h2" className="text-sm font-medium text-muted-foreground">
               Yearly budget
             </CardTitle>
           </CardHeader>

--- a/src/components/projects/uptime-calculator/SlaTargetInput.tsx
+++ b/src/components/projects/uptime-calculator/SlaTargetInput.tsx
@@ -98,6 +98,7 @@ export function SlaTargetInput({ value, onChange }: SlaTargetInputProps) {
                 value={inputValue}
                 onChange={handleInputChange}
                 onBlur={handleInputBlur}
+                aria-label="Target SLA percentage"
                 className="w-24 h-7 text-sm font-mono tabular-nums text-primary text-right pr-1"
               />
               <span className="text-sm text-primary">%</span>
@@ -105,6 +106,7 @@ export function SlaTargetInput({ value, onChange }: SlaTargetInputProps) {
           </div>
           <Slider
             id="sla-slider"
+            aria-label="Fine-tune target SLA percentage"
             value={[value]}
             onValueChange={([v]) => handleSliderChange(v)}
             min={MIN_SLA}

--- a/src/components/projects/uptime-calculator/TargetSummary.tsx
+++ b/src/components/projects/uptime-calculator/TargetSummary.tsx
@@ -55,7 +55,7 @@ export function TargetSummary({ result, achievableResult }: TargetSummaryProps) 
       {/* Budget visualization */}
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">Error Budget Usage</CardTitle>
+          <CardTitle as="h2" className="text-base">Error Budget Usage</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-2">

--- a/src/types/kanban.ts
+++ b/src/types/kanban.ts
@@ -299,12 +299,17 @@ export const roadmapBoard: KanbanBoard = {
     {
       id: 'in-progress',
       title: 'In Progress',
+      cards: [],
+    },
+    {
+      id: 'recently-completed',
+      title: 'Recently Completed',
       cards: [
         {
           id: 'kanban',
           title: 'Kanban Board',
           description: 'Interactive task board with drag-and-drop, URL persistence, card history, checklists, and column customization.',
-          labels: ['Medium', 'Content'],
+          labels: ['Medium', 'Content', 'PR #97'],
           planFile: 'docs/plans/15-kanban-page.md',
           checklist: [
             { id: 'kb-1', text: 'Core drag-and-drop with dnd-kit', completed: true },
@@ -312,16 +317,25 @@ export const roadmapBoard: KanbanBoard = {
             { id: 'kb-3', text: 'Card editor with history tracking', completed: true },
             { id: 'kb-4', text: 'Column customization (description, colors)', completed: true },
             { id: 'kb-5', text: 'Checklist/subtasks feature', completed: true },
-            { id: 'kb-6', text: 'Migrate roadmap plans to backlog cards', completed: false },
+            { id: 'kb-6', text: 'Migrate roadmap plans to backlog cards', completed: true },
           ],
           createdAt: '2026-01-13',
         },
-      ],
-    },
-    {
-      id: 'recently-completed',
-      title: 'Recently Completed',
-      cards: [
+        {
+          id: 'ci-failures',
+          title: 'Fix CI Failures (Lighthouse & Console)',
+          description: 'Fixed Runbook 404, blog sort test timeout, and project page accessibility scores.',
+          labels: ['CI', 'Testing', 'Accessibility'],
+          checklist: [
+            { id: 'ci-1', text: 'Investigate & fix Runbook page 404 error', completed: true },
+            { id: 'ci-2', text: 'Fix blog sort selector test timeout', completed: true },
+            { id: 'ci-3', text: 'Fix uptime-calculator accessibility (93% → 95%)', completed: true },
+            { id: 'ci-4', text: 'Fix statuspage-update accessibility (94% → 95%)', completed: true },
+            { id: 'ci-5', text: 'Fix oncall-coverage accessibility (94% → 95%)', completed: true },
+            { id: 'ci-6', text: 'Verify all CI checks pass', completed: true },
+          ],
+          createdAt: '2026-01-14',
+        },
         { id: 'skip-nav', title: 'Skip Navigation Links', labels: ['Small', 'Accessibility'], createdAt: '2026-01-13' },
         { id: 'analytics-dashboard', title: 'Analytics Dashboard', description: 'GA4, Search Console, Lighthouse visualizations', labels: ['PR #96'], createdAt: '2026-01-13' },
         { id: 'oncall-coverage', title: 'On-Call Coverage Model Explorer', labels: ['PR #94'], createdAt: '2026-01-13' },

--- a/tests/e2e/blog-functionality.spec.ts
+++ b/tests/e2e/blog-functionality.spec.ts
@@ -12,7 +12,8 @@ test.describe('Blog Functionality', () => {
 
   test('sort selector changes post order', async ({ page }) => {
     // Get initial first post title
-    const getFirstTitle = () => page.locator('a[href^="/blog/2"] h3, a[href^="/blog/2"] [class*="CardTitle"]').first().textContent();
+    // Structure is: h3.CardTitle > a[href="/blog/..."] > "Post Title"
+    const getFirstTitle = () => page.locator('h3 a[href^="/blog/2"], [class*="CardTitle"] a[href^="/blog/2"]').first().textContent();
     const firstPostBefore = await getFirstTitle();
 
     // Click sort trigger to open dropdown


### PR DESCRIPTION
## Summary
Fix CI failures in Console Error Check and Lighthouse CI workflows by addressing accessibility issues and test flakiness.

## The Journey
- Console Error Check was failing due to expected SPA 404s and a selector mismatch in blog tests
- Lighthouse CI was failing because project pages had 89-94% accessibility vs the 95% threshold
- Investigated specific violations: heading order, color contrast, missing ARIA labels
- Darkened color palette (-400 → -600) across heatmap components for WCAG AA compliance

## Changes
- **Console Error Check fixes:**
  - Ignore expected SPA routing 404s from own domain (GitHub Pages 404.html redirect)
  - Fix blog sort selector (`h3 > a` instead of `a > h3`)

- **Accessibility improvements:**
  - Fix heading order: `h4` → `h3` in Tradeoffs, DailyHeatmap
  - Add `as="h2"` to all CardTitle components (ResultsPanel, TargetSummary, etc.)
  - Add aria-label to SlaTargetInput slider
  - Darken color palette for better text contrast on colored backgrounds
  - Update REGION_COLORS and MEMBER_COLORS in types.ts

- **Kanban update:**
  - Move CI failures card to Recently Completed column with all items checked

## Test Plan
- [x] Run `npm run build` - passes
- [x] Run `npx playwright test` - 25 passed, 1 skipped
- [x] Run `npm test` - 158 tests pass
- [x] Verify Lighthouse CI passes in PR checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)