### PR TITLE
feat(kanban): add card-level color customization

### DIFF
--- a/src/components/projects/kanban/CardEditorModal.tsx
+++ b/src/components/projects/kanban/CardEditorModal.tsx
@@ -13,8 +13,11 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { X, History, Plus, FileText, ExternalLink } from 'lucide-react';
-import type { KanbanCard, CardChange, ChecklistItem } from '@/types/kanban';
-import { generateId } from '@/types/kanban';
+import { cn } from '@/lib/utils';
+import type { KanbanCard, CardChange, ChecklistItem, CardColor } from '@/types/kanban';
+import { generateId, CARD_COLORS } from '@/types/kanban';
+
+const colorKeys = Object.keys(CARD_COLORS) as CardColor[];
 
 function formatDate(dateStr: string): string {
   const date = new Date(dateStr);
@@ -64,6 +67,7 @@ export function CardEditorModal({
   const [newLabel, setNewLabel] = useState('');
   const [checklist, setChecklist] = useState<ChecklistItem[]>([]);
   const [newChecklistItem, setNewChecklistItem] = useState('');
+  const [color, setColor] = useState<CardColor | undefined>(undefined);
 
   useEffect(() => {
     if (card) {
@@ -71,11 +75,13 @@ export function CardEditorModal({
       setDescription(card.description || '');
       setLabels(card.labels || []);
       setChecklist(card.checklist || []);
+      setColor(card.color);
     } else {
       setTitle('');
       setDescription('');
       setLabels([]);
       setChecklist([]);
+      setColor(undefined);
     }
     setNewLabel('');
     setNewChecklistItem('');
@@ -111,6 +117,7 @@ export function CardEditorModal({
       description: description.trim() || undefined,
       labels: labels.length > 0 ? labels : undefined,
       checklist: checklist.length > 0 ? checklist : undefined,
+      color,
       createdAt: card?.createdAt || now,
       history: newHistory.length > 0 ? newHistory : undefined,
     });
@@ -222,6 +229,48 @@ export function CardEditorModal({
                 ))}
               </div>
             )}
+          </div>
+
+          {/* Color picker */}
+          <div className="space-y-2">
+            <Label>Color (optional)</Label>
+            <div className="flex flex-wrap gap-2">
+              {/* None button */}
+              <button
+                type="button"
+                onClick={() => setColor(undefined)}
+                title="None"
+                className={cn(
+                  'w-8 h-8 rounded-full border-2 transition-all bg-background',
+                  !color
+                    ? 'border-primary ring-2 ring-primary ring-offset-2 ring-offset-background'
+                    : 'border-border hover:scale-110'
+                )}
+              >
+                <span className="sr-only">None</span>
+              </button>
+              {colorKeys.filter(k => k !== 'default').map((colorKey) => {
+                const config = CARD_COLORS[colorKey];
+                const isSelected = color === colorKey;
+                return (
+                  <button
+                    key={colorKey}
+                    type="button"
+                    onClick={() => setColor(colorKey)}
+                    title={config.label}
+                    className={cn(
+                      'w-8 h-8 rounded-full border-2 transition-all',
+                      config.dot,
+                      isSelected
+                        ? 'border-primary ring-2 ring-primary ring-offset-2 ring-offset-background'
+                        : 'border-transparent hover:scale-110'
+                    )}
+                  >
+                    <span className="sr-only">{config.label}</span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
           {/* Checklist / Subtasks */}

--- a/src/components/projects/kanban/KanbanCard.tsx
+++ b/src/components/projects/kanban/KanbanCard.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Pencil, CheckSquare, FileText, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { KanbanCard as KanbanCardType } from '@/types/kanban';
+import { CARD_COLORS } from '@/types/kanban';
 
 const REPO_URL = 'https://github.com/Dbochman/personal-website';
 
@@ -36,12 +37,16 @@ export function KanbanCard({ card, onEdit, isDragOverlay = false }: KanbanCardPr
     transition,
   };
 
+  const colorConfig = card.color ? CARD_COLORS[card.color] : null;
+
   return (
     <Card
       ref={setNodeRef}
       style={style}
       className={cn(
-        'p-3 bg-background border shadow-sm cursor-grab active:cursor-grabbing touch-none group relative',
+        'p-3 border shadow-sm cursor-grab active:cursor-grabbing touch-none group relative',
+        colorConfig ? colorConfig.bg : 'bg-background',
+        colorConfig && colorConfig.border,
         isDragging && 'opacity-50',
         isDragOverlay && 'shadow-lg rotate-3'
       )}

--- a/src/types/kanban.ts
+++ b/src/types/kanban.ts
@@ -17,6 +17,11 @@ export interface ChecklistItem {
   completed: boolean;
 }
 
+export type ColumnColor = 'default' | 'yellow' | 'orange' | 'purple' | 'blue' | 'green' | 'red' | 'pink';
+
+// Card colors reuse the same palette as columns
+export type CardColor = ColumnColor;
+
 export interface KanbanCard {
   id: string;
   title: string;
@@ -24,12 +29,11 @@ export interface KanbanCard {
   labels?: string[];
   checklist?: ChecklistItem[];
   planFile?: string; // Path to plan file, e.g., 'docs/plans/11-framer-motion.md'
+  color?: CardColor;
   createdAt: string;
   updatedAt?: string;
   history?: CardChange[];
 }
-
-export type ColumnColor = 'default' | 'yellow' | 'orange' | 'purple' | 'blue' | 'green' | 'red' | 'pink';
 
 export const COLUMN_COLORS: Record<ColumnColor, { label: string; bg: string; border: string; dot: string }> = {
   default: { label: 'Default', bg: 'bg-muted/50', border: 'border-border', dot: 'bg-gray-400' },
@@ -41,6 +45,9 @@ export const COLUMN_COLORS: Record<ColumnColor, { label: string; bg: string; bor
   red: { label: 'Critical', bg: 'bg-red-500/10', border: 'border-red-500/30', dot: 'bg-red-500' },
   pink: { label: 'Review', bg: 'bg-pink-500/10', border: 'border-pink-500/30', dot: 'bg-pink-500' },
 };
+
+// Card colors use the same config as columns
+export const CARD_COLORS = COLUMN_COLORS;
 
 export interface KanbanColumn {
   id: string;


### PR DESCRIPTION
## Summary

Add optional color property to kanban cards, allowing visual categorization using the same 7-color palette as columns.

## The Journey

Following the column colors pattern, added card-level color support. Cards default to no color (standard background) for a clean look, with an optional color picker in the editor.

## Changes

- Add `CardColor` type and `CARD_COLORS` constant (aliases to column colors)
- Extend `KanbanCard` interface with optional `color` property
- Apply color background/border styling in `KanbanCard.tsx`
- Add color picker to `CardEditorModal` with "None" option for clearing color

## Test Plan

- [ ] Open `/projects/kanban` in browser
- [ ] Edit any card → color picker appears after labels section
- [ ] Select a color → card displays with colored background
- [ ] Select "None" → card returns to default white/dark background
- [ ] Create new card with color → color persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)