### PR TITLE
feat(analytics): add RUM Web Vitals alongside Lighthouse data

### DIFF
--- a/src/components/analytics/AnalyticsDashboard.tsx
+++ b/src/components/analytics/AnalyticsDashboard.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Activity, Search, Gauge, Users } from 'lucide-react';
 import { MetricCard } from './MetricCard';
 import { CoreWebVitalsCard } from './CoreWebVitalsCard';
+import { RumWebVitalsCard } from './RumWebVitalsCard';
 import { LighthouseScoresTable } from './LighthouseScoresTable';
 import { SessionsTrendChart } from './charts/SessionsTrendChart';
 import { DeviceBreakdownChart } from './charts/DeviceBreakdownChart';
@@ -201,17 +202,27 @@ export function AnalyticsDashboard() {
 
         {/* Performance Tab */}
         <TabsContent value="performance" className="space-y-4">
+          {/* Web Vitals Comparison: Lab vs Field */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>Lighthouse Scores</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <LighthouseHistoryChart data={lighthouseSummary} />
-              </CardContent>
-            </Card>
-            <CoreWebVitalsCard data={lighthouseSummary} />
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-muted-foreground">Lab Data (Lighthouse)</h3>
+              <CoreWebVitalsCard data={lighthouseSummary} />
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-muted-foreground">Field Data (Real Users)</h3>
+              <RumWebVitalsCard data={latest?.webVitals} />
+            </div>
           </div>
+
+          {/* Lighthouse Scores Chart */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Lighthouse Scores by Page</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <LighthouseHistoryChart data={lighthouseSummary} />
+            </CardContent>
+          </Card>
 
           <LighthouseScoresTable data={lighthouseSummary} />
         </TabsContent>

--- a/src/components/analytics/RumWebVitalsCard.tsx
+++ b/src/components/analytics/RumWebVitalsCard.tsx
@@ -1,0 +1,123 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { cn } from '@/lib/utils';
+import type { WebVitalsData } from './types';
+
+interface RumWebVitalsCardProps {
+  data: WebVitalsData | null | undefined;
+}
+
+interface VitalConfig {
+  key: 'LCP' | 'FCP' | 'CLS' | 'INP' | 'TTFB';
+  label: string;
+  thresholds: { good: number; poor: number };
+  format: (value: number) => string;
+}
+
+const vitals: VitalConfig[] = [
+  {
+    key: 'LCP',
+    label: 'Largest Contentful Paint',
+    thresholds: { good: 2500, poor: 4000 },
+    format: (v) => `${(v / 1000).toFixed(2)}s`,
+  },
+  {
+    key: 'FCP',
+    label: 'First Contentful Paint',
+    thresholds: { good: 1800, poor: 3000 },
+    format: (v) => `${(v / 1000).toFixed(2)}s`,
+  },
+  {
+    key: 'CLS',
+    label: 'Cumulative Layout Shift',
+    thresholds: { good: 0.1, poor: 0.25 },
+    format: (v) => v.toFixed(4),
+  },
+  {
+    key: 'INP',
+    label: 'Interaction to Next Paint',
+    thresholds: { good: 200, poor: 500 },
+    format: (v) => `${Math.round(v)}ms`,
+  },
+  {
+    key: 'TTFB',
+    label: 'Time to First Byte',
+    thresholds: { good: 800, poor: 1800 },
+    format: (v) => `${Math.round(v)}ms`,
+  },
+];
+
+function getStatus(value: number, thresholds: { good: number; poor: number }): 'good' | 'warning' | 'critical' {
+  if (value <= thresholds.good) return 'good';
+  if (value <= thresholds.poor) return 'warning';
+  return 'critical';
+}
+
+export function RumWebVitalsCard({ data }: RumWebVitalsCardProps) {
+  if (!data || !data.metrics || Object.keys(data.metrics).length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Real User Metrics</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">No RUM data available yet. Data will appear after users visit the site.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const statusText = {
+    good: 'Good',
+    warning: 'Needs Improvement',
+    critical: 'Poor',
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Real User Metrics</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Field data from {data.metrics.LCP?.count || data.metrics.FCP?.count || 0}+ sessions
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {vitals.map((vital) => {
+          const metric = data.metrics[vital.key];
+          if (!metric) return null;
+
+          const value = metric.average;
+          const status = getStatus(value, vital.thresholds);
+          const progressValue = Math.min((value / vital.thresholds.poor) * 100, 100);
+
+          return (
+            <div key={vital.key} className="space-y-1">
+              <div className="flex justify-between text-sm">
+                <span className="font-medium">{vital.key}</span>
+                <span className={cn('font-mono', {
+                  'text-emerald-500': status === 'good',
+                  'text-amber-500': status === 'warning',
+                  'text-red-500': status === 'critical',
+                })}>
+                  {vital.format(value)}
+                  <span className="text-muted-foreground text-xs ml-2">
+                    ({statusText[status]})
+                  </span>
+                </span>
+              </div>
+              <Progress
+                value={progressValue}
+                className="h-2"
+                aria-label={`${vital.key}: ${vital.format(value)}`}
+              />
+              <div className="flex justify-between text-xs text-muted-foreground">
+                <span>Good: ≤{vital.key === 'CLS' ? vital.thresholds.good : `${vital.thresholds.good}ms`}</span>
+                <span>Poor: &gt;{vital.key === 'CLS' ? vital.thresholds.poor : `${vital.thresholds.poor}ms`}</span>
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/analytics/index.ts
+++ b/src/components/analytics/index.ts
@@ -1,5 +1,6 @@
 export { AnalyticsDashboard } from './AnalyticsDashboard';
 export { MetricCard } from './MetricCard';
 export { CoreWebVitalsCard } from './CoreWebVitalsCard';
+export { RumWebVitalsCard } from './RumWebVitalsCard';
 export { LighthouseScoresTable } from './LighthouseScoresTable';
 export type * from './types';

--- a/src/components/analytics/types.ts
+++ b/src/components/analytics/types.ts
@@ -1,5 +1,23 @@
 // Types for analytics data from docs/metrics/*.json
 
+export interface WebVitalMetric {
+  count: number;
+  average: number;
+  unit: string;
+}
+
+export interface WebVitalsData {
+  lastCheck: string;
+  source: 'rum';
+  metrics: {
+    LCP?: WebVitalMetric;
+    FCP?: WebVitalMetric;
+    CLS?: WebVitalMetric;
+    INP?: WebVitalMetric;
+    TTFB?: WebVitalMetric;
+  };
+}
+
 export interface LatestMetrics {
   generated: string;
   searchConsole: {
@@ -18,6 +36,7 @@ export interface LatestMetrics {
     bounceRate: number;
     topPages: Array<{ page: string; pageViews: number }>;
   };
+  webVitals?: WebVitalsData;
 }
 
 export interface GA4HistoryEntry {


### PR DESCRIPTION
## Summary
Display real user monitoring (RUM) Web Vitals alongside Lighthouse lab data in the Analytics dashboard, giving a complete picture of actual vs synthetic performance.

## The Journey
- Noticed the Lighthouse scores (perfect 100s) didn't match real-world user experience expectations
- Realized we needed to distinguish between lab data (synthetic tests) and field data (actual users)
- Already had RUM collection in place via GA4 Web Vitals events from `reportWebVitals.ts`
- Created a side-by-side comparison to show both perspectives

## Changes
- Add `RumWebVitalsCard` component showing field data with threshold-based status indicators
- Add `WebVitalsData` and `WebVitalMetric` types for RUM metrics
- Restructure Performance tab to show Lab (Lighthouse) vs Field (RUM) comparison
- Display session counts to show sample sizes

## Test Plan
- [x] Visit `/analytics` and check the Performance tab
- [x] Verify Lab Data card shows Lighthouse metrics
- [x] Verify Field Data card shows RUM metrics from actual users
- [x] Check responsive layout on mobile (cards should stack)
- [x] Build passes: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)