### PR TITLE
feat(projects): add Analytics Dashboard as a project

### DIFF
--- a/src/components/projects/analytics/index.tsx
+++ b/src/components/projects/analytics/index.tsx
@@ -1,0 +1,13 @@
+import { AnalyticsDashboard } from '@/components/analytics';
+
+export default function Analytics() {
+  return (
+    <div className="space-y-6">
+      <p className="text-muted-foreground">
+        Site performance metrics combining Google Analytics, Search Console, Lighthouse audits,
+        and Real User Monitoring (RUM) data. Updated daily via GitHub Actions.
+      </p>
+      <AnalyticsDashboard />
+    </div>
+  );
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -14,6 +14,9 @@ const OncallCoverage = lazy(
 const Kanban = lazy(
   () => import('@/components/projects/kanban')
 );
+const Analytics = lazy(
+  () => import('@/components/projects/analytics')
+);
 
 /**
  * Project registry - single source of truth for all projects
@@ -64,6 +67,18 @@ export const projectRegistry: ProjectDefinition[] = [
     createdAt: '2026-01-13',
     fullWidth: true,
     component: Kanban,
+  },
+  {
+    slug: 'analytics',
+    title: 'Site Analytics Dashboard',
+    description:
+      'Unified view of site performance: GA4 traffic, Search Console rankings, Lighthouse audits, and Real User Monitoring. Data pipelines via GitHub Actions.',
+    tags: ['Analytics', 'Performance', 'Observability'],
+    icon: 'BarChart3',
+    status: 'active',
+    createdAt: '2026-01-14',
+    fullWidth: true,
+    component: Analytics,
   },
 ];
 


### PR DESCRIPTION
## Summary
Add the Analytics Dashboard as a discoverable project alongside other SRE tools.

## Changes
- Create `src/components/projects/analytics/index.tsx` wrapper component
- Add Analytics entry to project registry with BarChart3 icon
- Tags: Analytics, Performance, Observability
- Full-width layout to accommodate dashboard charts

## Test Plan
- [x] Visit `/projects` - Analytics should appear in the grid
- [x] Click Analytics card - should navigate to `/projects/analytics`
- [x] Dashboard should load with all tabs (Traffic, Performance, Search)
- [ ] Build passes: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)