### PR TITLE
fix: Sync incident count between SLO tools

### DIFF
--- a/.claude/session-notes.md
+++ b/.claude/session-notes.md
@@ -102,6 +102,28 @@ Fixed both—now 404s show yellow warnings, actual errors (500s, network) show r
 
 ---
 
+## 2026-01-16 (SLO Tools Polish)
+
+**Slider magnetism pattern:** When using sliders for values with common presets (like SLO percentages), add snap points that pull the slider toward round numbers. Implementation in `src/lib/slo/presets.ts`:
+
+```typescript
+export function snapToPreset(value: number): number {
+  for (const snapPoint of SNAP_POINTS) {
+    const threshold = snapPoint >= 99.9 ? 0.015 : 0.1;
+    if (Math.abs(value - snapPoint) <= threshold) {
+      return snapPoint;
+    }
+  }
+  return value;
+}
+```
+
+Use adaptive thresholds - tighter for high-precision values where small differences matter. Call it in the slider's `onValueChange` handler.
+
+**Flexible input ranges:** For SLO tools, the text input accepts 0-99.999% while sliders focus on realistic ranges (90-99.999% or 99-99.999%). This lets power users enter any value while keeping the slider UX focused.
+
+---
+
 ## 2026-01-16
 
 **Cloudflare Pages preview deployments.** Set up branch preview infrastructure so PRs get unique preview URLs automatically.

--- a/src/components/projects/error-budget-burndown/IncidentList.tsx
+++ b/src/components/projects/error-budget-burndown/IncidentList.tsx
@@ -19,6 +19,8 @@ interface IncidentListProps {
   onChange: (incidents: Incident[]) => void;
   periodStartDate: string;
   periodDays: number;
+  initialFrequency?: number;
+  onFrequencyChange?: (frequency: number) => void;
 }
 
 const INCIDENT_NAMES = [
@@ -83,13 +85,20 @@ function generateExampleIncidents(
   return incidents;
 }
 
-export function IncidentList({ incidents, onChange, periodStartDate, periodDays }: IncidentListProps) {
+export function IncidentList({
+  incidents,
+  onChange,
+  periodStartDate,
+  periodDays,
+  initialFrequency = 4,
+  onFrequencyChange,
+}: IncidentListProps) {
   const [mode, setMode] = useState<'auto' | 'manual'>('auto');
   const [isAdding, setIsAdding] = useState(false);
   const [autoConfig, setAutoConfig] = useState<AutoGenerateConfig>({
     avgDuration: 20,
     avgImpact: 20,
-    frequency: 4,
+    frequency: initialFrequency,
   });
   const [newIncident, setNewIncident] = useState<Omit<Incident, 'id'>>({
     name: '',
@@ -101,13 +110,19 @@ export function IncidentList({ incidents, onChange, periodStartDate, periodDays 
   // Store manual incidents separately so they're preserved when toggling modes
   const savedManualIncidents = useRef<Incident[]>([]);
 
+  // Sync frequency when initialFrequency prop changes (e.g., from URL params)
+  useEffect(() => {
+    setAutoConfig((prev) => ({ ...prev, frequency: initialFrequency }));
+  }, [initialFrequency]);
+
   // Generate incidents when auto config changes
   useEffect(() => {
     if (mode === 'auto') {
       const generated = generateExampleIncidents(autoConfig, periodStartDate, periodDays);
       onChange(generated);
+      onFrequencyChange?.(autoConfig.frequency);
     }
-  }, [mode, autoConfig, periodStartDate, periodDays, onChange]);
+  }, [mode, autoConfig, periodStartDate, periodDays, onChange, onFrequencyChange]);
 
   const handleModeChange = (checked: boolean) => {
     const newMode = checked ? 'manual' : 'auto';

--- a/src/components/projects/error-budget-burndown/index.tsx
+++ b/src/components/projects/error-budget-burndown/index.tsx
@@ -26,36 +26,49 @@ export default function ErrorBudgetBurndown() {
   // Input allows full range; slider focuses on high-availability targets
   const MIN_SLO = 0;
   const MAX_SLO = 99.999;
+  const MIN_INCIDENTS = 0;
+  const MAX_INCIDENTS = 20;
 
-  const [config, setConfig] = useState<SloConfig>(() => {
-    // Initialize from URL params if present, clamping to valid range
+  // Parse URL params for cross-tool linking
+  const getInitialParams = () => {
     const sloParam = searchParams.get('slo');
-    let initialTarget = 99.9;
+    const incidentsParam = searchParams.get('incidents');
+
+    let slo = 99.9;
     if (sloParam) {
       const parsed = parseFloat(sloParam);
       if (!isNaN(parsed)) {
-        initialTarget = Math.min(MAX_SLO, Math.max(MIN_SLO, parsed));
+        slo = Math.min(MAX_SLO, Math.max(MIN_SLO, parsed));
       }
     }
-    return {
-      target: initialTarget,
-      period: 'monthly',
-      startDate: getDefaultStartDate(),
-    };
+
+    let incidents = 4;
+    if (incidentsParam) {
+      const parsed = parseInt(incidentsParam, 10);
+      if (!isNaN(parsed)) {
+        incidents = Math.min(MAX_INCIDENTS, Math.max(MIN_INCIDENTS, parsed));
+      }
+    }
+
+    return { slo, incidents };
+  };
+
+  const initialParams = getInitialParams();
+
+  const [config, setConfig] = useState<SloConfig>({
+    target: initialParams.slo,
+    period: 'monthly',
+    startDate: getDefaultStartDate(),
   });
 
   const [incidents, setIncidents] = useState<Incident[]>([]);
+  const [incidentFrequency, setIncidentFrequency] = useState(initialParams.incidents);
 
   // Update config if URL params change (e.g., from cross-tool navigation)
   useEffect(() => {
-    const sloParam = searchParams.get('slo');
-    if (sloParam) {
-      const parsed = parseFloat(sloParam);
-      if (!isNaN(parsed)) {
-        const clamped = Math.min(MAX_SLO, Math.max(MIN_SLO, parsed));
-        setConfig((prev) => ({ ...prev, target: clamped }));
-      }
-    }
+    const params = getInitialParams();
+    setConfig((prev) => ({ ...prev, target: params.slo }));
+    setIncidentFrequency(params.incidents);
   }, [searchParams]);
 
   const calculation = calculateBudget(config, incidents);
@@ -75,6 +88,8 @@ export default function ErrorBudgetBurndown() {
           onChange={setIncidents}
           periodStartDate={config.startDate}
           periodDays={PERIOD_DAYS[config.period]}
+          initialFrequency={incidentFrequency}
+          onFrequencyChange={setIncidentFrequency}
         />
       </div>
 
@@ -89,7 +104,7 @@ export default function ErrorBudgetBurndown() {
       {/* Cross-tool link */}
       <div className="pt-4 border-t">
         <Link
-          to={`/projects/uptime-calculator?slo=${config.target}&mode=target`}
+          to={`/projects/uptime-calculator?slo=${config.target}&mode=target&incidents=${incidentFrequency}`}
           className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors"
         >
           Improve your incident response times

--- a/src/components/projects/uptime-calculator/index.tsx
+++ b/src/components/projects/uptime-calculator/index.tsx
@@ -228,7 +228,7 @@ export default function UptimeCalculator() {
         {/* Cross-tool link */}
         <div className="mt-6 pt-4 border-t">
           <Link
-            to={`/projects/error-budget?slo=${mode === 'achievable' ? achievableResult.maxAchievableSlo.toFixed(2) : targetSlo}`}
+            to={`/projects/error-budget?slo=${mode === 'achievable' ? achievableResult.maxAchievableSlo.toFixed(2) : targetSlo}&incidents=${incidentsPerMonth}`}
             className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors"
           >
             See how incidents impact your error budget


### PR DESCRIPTION
## Summary
Keeps incident count in sync when navigating between SLO Calculator and Error Budget Burndown via cross-links.

## Changes
- SLO Calculator now passes `&incidents=X` in link to Error Budget
- Error Budget reads `incidents` URL param and initializes the frequency slider
- Error Budget passes `&incidents=X` back to SLO Calculator

## Test plan
- [ ] Set incidents to 8 in SLO Calculator → click cross-link → Error Budget shows 8
- [ ] Change to 12 in Error Budget → click cross-link → SLO Calculator shows 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)