### PR TITLE
feat(slo-tool): Improve defaults and add collapsible response times

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://dylanbochman.com/</loc>
-    <lastmod>2026-01-16</lastmod>
+    <lastmod>2026-01-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/blog</loc>
-    <lastmod>2026-01-16</lastmod>
+    <lastmod>2026-01-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects</loc>
-    <lastmod>2026-01-16</lastmod>
+    <lastmod>2026-01-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/components/projects/slo-tool/BudgetChart.tsx
+++ b/src/components/projects/slo-tool/BudgetChart.tsx
@@ -174,21 +174,27 @@ export function BudgetChart({
 
         {/* Legend - only show on full version */}
         {!compact && (
-          <div className="flex flex-wrap gap-4 justify-center mt-4 text-sm">
-            <div className="flex items-center gap-2">
-              <div className="w-4 h-0.5 border-t-2 border-dashed border-muted-foreground" />
-              <span className="text-muted-foreground">Ideal</span>
+          <div className="mt-4 space-y-2">
+            <div className="flex flex-wrap gap-4 justify-center text-sm">
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-0.5 border-t-2 border-dashed border-muted-foreground" />
+                <span className="text-muted-foreground">Ideal</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-0.5 bg-primary" />
+                <span className="text-muted-foreground">Actual</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div
+                  className={`w-4 h-0.5 border-t-2 border-dashed ${isOnTrack ? 'border-green-500' : 'border-destructive'}`}
+                />
+                <span className="text-muted-foreground">Projected</span>
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <div className="w-4 h-0.5 bg-primary" />
-              <span className="text-muted-foreground">Actual</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div
-                className={`w-4 h-0.5 border-t-2 border-dashed ${isOnTrack ? 'border-green-500' : 'border-destructive'}`}
-              />
-              <span className="text-muted-foreground">Projected</span>
-            </div>
+            <p className="text-xs text-muted-foreground text-center">
+              The "ideal" line represents a linear burn rate—it assumes you'll burn through your
+              entire error budget evenly over the period, reaching exactly 0 at the end.
+            </p>
           </div>
         )}
       </CardContent>

--- a/src/components/projects/slo-tool/ResponseTimeInputs.tsx
+++ b/src/components/projects/slo-tool/ResponseTimeInputs.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { Slider } from '@/components/ui/slider';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Eye, EyeOff } from 'lucide-react';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Eye, EyeOff, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { ResponseProfile } from './calculations';
 
@@ -60,63 +62,129 @@ const INPUT_CONFIG: InputConfig[] = [
   },
 ];
 
+function ResponseTimeSlider({
+  field,
+  label,
+  description,
+  max,
+  value,
+  isEnabled,
+  onChange,
+  onToggle,
+}: {
+  field: keyof ResponseProfile;
+  label: string;
+  description: string;
+  max: number;
+  value: number;
+  isEnabled: boolean;
+  onChange: (field: keyof ResponseProfile, value: number) => void;
+  onToggle: (field: keyof ResponseProfile) => void;
+}) {
+  return (
+    <div className={`space-y-2 ${!isEnabled ? 'opacity-50' : ''}`}>
+      <div className="flex justify-between items-start">
+        <div className="flex items-start gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0"
+            onClick={() => onToggle(field)}
+            aria-label={
+              isEnabled ? `Exclude ${label} from calculation` : `Include ${label} in calculation`
+            }
+          >
+            {isEnabled ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+          </Button>
+          <div>
+            <Label htmlFor={field} className="text-sm font-medium">
+              {label}
+            </Label>
+            <p className="text-xs text-muted-foreground">{description}</p>
+          </div>
+        </div>
+        <span className="text-sm font-mono tabular-nums text-primary">
+          {isEnabled ? `${value} min` : 'excluded'}
+        </span>
+      </div>
+      <Slider
+        id={field}
+        aria-label={label}
+        value={[value]}
+        onValueChange={([v]) => onChange(field, v)}
+        min={0}
+        max={max}
+        step={1}
+        className="w-full"
+        disabled={!isEnabled}
+      />
+    </div>
+  );
+}
+
 export function ResponseTimeInputs({
   profile,
   enabledPhases,
   onChange,
   onToggle,
 }: ResponseTimeInputsProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const firstInput = INPUT_CONFIG[0];
+  const restInputs = INPUT_CONFIG.slice(1);
+
   return (
     <Card>
-      <CardHeader className="pb-4">
-        <CardTitle as="h2" className="text-base">Response Times (per incident)</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {INPUT_CONFIG.map(({ field, label, description, max }) => {
-          const isEnabled = enabledPhases[field];
-          return (
-            <div key={field} className={`space-y-2 ${!isEnabled ? 'opacity-50' : ''}`}>
-              <div className="flex justify-between items-start">
-                <div className="flex items-start gap-2">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 shrink-0"
-                    onClick={() => onToggle(field)}
-                    aria-label={
-                      isEnabled
-                        ? `Exclude ${label} from calculation`
-                        : `Include ${label} in calculation`
-                    }
-                  >
-                    {isEnabled ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
-                  </Button>
-                  <div>
-                    <Label htmlFor={field} className="text-sm font-medium">
-                      {label}
-                    </Label>
-                    <p className="text-xs text-muted-foreground">{description}</p>
-                  </div>
-                </div>
-                <span className="text-sm font-mono tabular-nums text-primary">
-                  {isEnabled ? `${profile[field]} min` : 'excluded'}
-                </span>
+      <Collapsible open={expanded} onOpenChange={setExpanded}>
+        <CardHeader className="pb-4">
+          <CollapsibleTrigger asChild>
+            <button
+              className="flex items-center justify-between w-full text-left group"
+              aria-expanded={expanded}
+            >
+              <CardTitle as="h2" className="text-base">Response Times (per incident)</CardTitle>
+              <div className="flex items-center gap-1 text-sm text-muted-foreground group-hover:text-foreground transition-colors">
+                <span>{expanded ? 'Less options' : 'More options'}</span>
+                <ChevronDown
+                  className={`h-4 w-4 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+                />
               </div>
-              <Slider
-                id={field}
-                aria-label={label}
-                value={[profile[field]]}
-                onValueChange={([value]) => onChange(field, value)}
-                min={0}
-                max={max}
-                step={1}
-                className="w-full"
-                disabled={!isEnabled}
-              />
+            </button>
+          </CollapsibleTrigger>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Always show first input */}
+          <ResponseTimeSlider
+            field={firstInput.field}
+            label={firstInput.label}
+            description={firstInput.description}
+            max={firstInput.max}
+            value={profile[firstInput.field]}
+            isEnabled={enabledPhases[firstInput.field]}
+            onChange={onChange}
+            onToggle={onToggle}
+          />
+
+          {/* Collapsible section for remaining inputs */}
+          <CollapsibleContent className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
+            <div className="space-y-6">
+              {restInputs.map(({ field, label, description, max }) => (
+                <ResponseTimeSlider
+                  key={field}
+                  field={field}
+                  label={label}
+                  description={description}
+                  max={max}
+                  value={profile[field]}
+                  isEnabled={enabledPhases[field]}
+                  onChange={onChange}
+                  onToggle={onToggle}
+                />
+              ))}
             </div>
-          );
-        })}
-      </CardContent>
+          </CollapsibleContent>
+        </CardContent>
+      </Collapsible>
     </Card>
   );
 }

--- a/src/components/projects/slo-tool/index.tsx
+++ b/src/components/projects/slo-tool/index.tsx
@@ -9,7 +9,6 @@ import { Label } from '@/components/ui/label';
 import { SloConfiguration } from './SloConfiguration';
 import { ResponseTimeInputs, type EnabledPhases } from './ResponseTimeInputs';
 import { IncidentInput } from './IncidentInput';
-import { BudgetChart } from './BudgetChart';
 import { AchievableTab } from './AchievableTab';
 import { TargetTab } from './TargetTab';
 import { BurndownTab } from './BurndownTab';
@@ -23,7 +22,6 @@ import {
   calculateAchievableSlo,
   calculateCanMeetSlo,
   calculateBudget,
-  generateChartData,
   generateSimulatedIncidents,
   getEffectiveProfile,
   toLocalDateString,
@@ -83,7 +81,7 @@ function parseUrlParams(searchParams: URLSearchParams) {
 const DEFAULT_ENABLED: EnabledPhases = {
   alertLatencyMin: true,
   acknowledgeMin: true,
-  travelMin: true,
+  travelMin: false,
   authMin: true,
   diagnoseMin: true,
   fixMin: true,
@@ -111,7 +109,7 @@ export default function SloTool() {
   const [enabledPhases, setEnabledPhases] = useState<EnabledPhases>(DEFAULT_ENABLED);
   const [incidentsPerPeriod, setIncidentsPerPeriod] = useState(() => {
     const params = parseUrlParams(searchParams);
-    return params.incidents ?? 4;
+    return params.incidents ?? 1;
   });
   const [configExpanded, setConfigExpanded] = useState(false);
 
@@ -223,7 +221,6 @@ export default function SloTool() {
   );
 
   const budgetCalculation = calculateBudget(config, simulatedIncidents);
-  const chartData = generateChartData(config, simulatedIncidents, budgetCalculation);
 
   return (
     <div className="space-y-6">
@@ -352,13 +349,6 @@ export default function SloTool() {
           {/* Tab-specific content */}
           <TabsContent value="achievable" className="mt-0 space-y-6">
             <AchievableTab result={achievableResult} period={config.period} />
-            <BudgetChart
-              data={chartData}
-              daysElapsed={budgetCalculation.daysElapsed}
-              isOnTrack={budgetCalculation.isOnTrack}
-              compact
-              title="Projected Budget Burndown"
-            />
           </TabsContent>
 
           <TabsContent value="target" className="mt-0 space-y-6">
@@ -367,17 +357,14 @@ export default function SloTool() {
               achievableResult={achievableResult}
               period={config.period}
             />
-            <BudgetChart
-              data={chartData}
-              daysElapsed={budgetCalculation.daysElapsed}
-              isOnTrack={budgetCalculation.isOnTrack}
-              compact
-              title="Projected Budget Burndown"
-            />
           </TabsContent>
 
           <TabsContent value="burndown" className="mt-0">
-            <BurndownTab calculation={budgetCalculation} chartData={chartData} />
+            <BurndownTab
+              calculation={budgetCalculation}
+              config={config}
+              incidents={simulatedIncidents}
+            />
           </TabsContent>
         </div>
       </Tabs>


### PR DESCRIPTION
## Summary
Update SLO Calculator defaults and add collapsible response times section for a cleaner initial view.

## Changes
- **New default values**: More realistic incident response profile
  - Time to authenticate: 1 min (was 3)
  - Time to diagnose: 5 min (was 15)
  - Time to fix: 10 min (was 20)
  - Time to computer: excluded by default
  - Incidents per month: 1 (was 4)

- **Collapsible response times**: Only Alert latency visible by default
  - Clickable header with "More options ∨" to expand
  - Consistent pattern with Target/Burndown tabs' collapsible config

## Test Plan
- [x] Verify default values match expected profile
- [x] Expand/collapse animation works smoothly
- [x] "More options" / "Less options" text toggles correctly
- [ ] Check mobile responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)