### PR TITLE
style(projects): icon inline with title + hero backgrounds

### DIFF
--- a/.cursor/commands/ui-skills.md
+++ b/.cursor/commands/ui-skills.md
@@ -1,0 +1,85 @@
+---
+name: ui-skills
+description: Opinionated constraints for building better interfaces with agents.
+---
+
+# UI Skills
+
+When invoked, apply these opinionated constraints for building better interfaces.
+
+## How to use
+
+- `/ui-skills`  
+  Apply these constraints to any UI work in this conversation.
+
+- `/ui-skills <file>`  
+  Review the file against all constraints below and output:
+  - violations (quote the exact line/snippet)
+  - why it matters (1 short sentence)
+  - a concrete fix (code-level suggestion)
+
+## Stack
+
+- MUST use Tailwind CSS defaults unless custom values already exist or are explicitly requested
+- MUST use `motion/react` (formerly `framer-motion`) when JavaScript animation is required
+- SHOULD use `tw-animate-css` for entrance and micro-animations in Tailwind CSS
+- MUST use `cn` utility (`clsx` + `tailwind-merge`) for class logic
+
+## Components
+
+- MUST use accessible component primitives for anything with keyboard or focus behavior (`Base UI`, `React Aria`, `Radix`)
+- MUST use the project’s existing component primitives first
+- NEVER mix primitive systems within the same interaction surface
+- SHOULD prefer [`Base UI`](https://base-ui.com/react/components) for new primitives if compatible with the stack
+- MUST add an `aria-label` to icon-only buttons
+- NEVER rebuild keyboard or focus behavior by hand unless explicitly requested
+
+## Interaction
+
+- MUST use an `AlertDialog` for destructive or irreversible actions
+- SHOULD use structural skeletons for loading states
+- NEVER use `h-screen`, use `h-dvh`
+- MUST respect `safe-area-inset` for fixed elements
+- MUST show errors next to where the action happens
+- NEVER block paste in `input` or `textarea` elements
+
+## Animation
+
+- NEVER add animation unless it is explicitly requested
+- MUST animate only compositor props (`transform`, `opacity`)
+- NEVER animate layout properties (`width`, `height`, `top`, `left`, `margin`, `padding`)
+- SHOULD avoid animating paint properties (`background`, `color`) except for small, local UI (text, icons)
+- SHOULD use `ease-out` on entrance
+- NEVER exceed `200ms` for interaction feedback
+- MUST pause looping animations when off-screen
+- SHOULD respect `prefers-reduced-motion`
+- NEVER introduce custom easing curves unless explicitly requested
+- SHOULD avoid animating large images or full-screen surfaces
+
+## Typography
+
+- MUST use `text-balance` for headings and `text-pretty` for body/paragraphs
+- MUST use `tabular-nums` for data
+- SHOULD use `truncate` or `line-clamp` for dense UI
+- NEVER modify `letter-spacing` (`tracking-*`) unless explicitly requested
+
+## Layout
+
+- MUST use a fixed `z-index` scale (no arbitrary `z-*`)
+- SHOULD use `size-*` for square elements instead of `w-*` + `h-*`
+
+## Performance
+
+- NEVER animate large `blur()` or `backdrop-filter` surfaces
+- NEVER apply `will-change` outside an active animation
+- NEVER use `useEffect` for anything that can be expressed as render logic
+
+## Design
+
+- NEVER use gradients unless explicitly requested
+- NEVER use purple or multicolor gradients
+- NEVER use glow effects as primary affordances
+- SHOULD use Tailwind CSS default shadow scale unless explicitly requested
+- MUST give empty states one clear next action
+- SHOULD limit accent color usage to one per view
+- SHOULD use existing theme or Tailwind CSS color tokens before introducing new ones

--- a/.cursor/skills/ui-skills/SKILL.md
+++ b/.cursor/skills/ui-skills/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ui-skills
+description: Opinionated constraints for building better interfaces with agents.
+---
+
+# UI Skills
+
+When invoked, apply these opinionated constraints for building better interfaces.
+
+## How to use
+
+- `/ui-skills`  
+  Apply these constraints to any UI work in this conversation.
+
+- `/ui-skills <file>`  
+  Review the file against all constraints below and output:
+  - violations (quote the exact line/snippet)
+  - why it matters (1 short sentence)
+  - a concrete fix (code-level suggestion)
+
+## Stack
+
+- MUST use Tailwind CSS defaults unless custom values already exist or are explicitly requested
+- MUST use `motion/react` (formerly `framer-motion`) when JavaScript animation is required
+- SHOULD use `tw-animate-css` for entrance and micro-animations in Tailwind CSS
+- MUST use `cn` utility (`clsx` + `tailwind-merge`) for class logic
+
+## Components
+
+- MUST use accessible component primitives for anything with keyboard or focus behavior (`Base UI`, `React Aria`, `Radix`)
+- MUST use the project’s existing component primitives first
+- NEVER mix primitive systems within the same interaction surface
+- SHOULD prefer [`Base UI`](https://base-ui.com/react/components) for new primitives if compatible with the stack
+- MUST add an `aria-label` to icon-only buttons
+- NEVER rebuild keyboard or focus behavior by hand unless explicitly requested
+
+## Interaction
+
+- MUST use an `AlertDialog` for destructive or irreversible actions
+- SHOULD use structural skeletons for loading states
+- NEVER use `h-screen`, use `h-dvh`
+- MUST respect `safe-area-inset` for fixed elements
+- MUST show errors next to where the action happens
+- NEVER block paste in `input` or `textarea` elements
+
+## Animation
+
+- NEVER add animation unless it is explicitly requested
+- MUST animate only compositor props (`transform`, `opacity`)
+- NEVER animate layout properties (`width`, `height`, `top`, `left`, `margin`, `padding`)
+- SHOULD avoid animating paint properties (`background`, `color`) except for small, local UI (text, icons)
+- SHOULD use `ease-out` on entrance
+- NEVER exceed `200ms` for interaction feedback
+- MUST pause looping animations when off-screen
+- SHOULD respect `prefers-reduced-motion`
+- NEVER introduce custom easing curves unless explicitly requested
+- SHOULD avoid animating large images or full-screen surfaces
+
+## Typography
+
+- MUST use `text-balance` for headings and `text-pretty` for body/paragraphs
+- MUST use `tabular-nums` for data
+- SHOULD use `truncate` or `line-clamp` for dense UI
+- NEVER modify `letter-spacing` (`tracking-*`) unless explicitly requested
+
+## Layout
+
+- MUST use a fixed `z-index` scale (no arbitrary `z-*`)
+- SHOULD use `size-*` for square elements instead of `w-*` + `h-*`
+
+## Performance
+
+- NEVER animate large `blur()` or `backdrop-filter` surfaces
+- NEVER apply `will-change` outside an active animation
+- NEVER use `useEffect` for anything that can be expressed as render logic
+
+## Design
+
+- NEVER use gradients unless explicitly requested
+- NEVER use purple or multicolor gradients
+- NEVER use glow effects as primary affordances
+- SHOULD use Tailwind CSS default shadow scale unless explicitly requested
+- MUST give empty states one clear next action
+- SHOULD limit accent color usage to one per view
+- SHOULD use existing theme or Tailwind CSS color tokens before introducing new ones

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -192,91 +192,81 @@ export default function Project() {
       </Helmet>
 
       <PageLayout>
-        {/* Hero section for view transition */}
-        {!project.fullWidth && (
-          <div className="relative h-48 md:h-56 flex items-center justify-center bg-gradient-to-b from-foreground/5 via-foreground/[0.02] to-transparent mb-6">
-            {/* Icon - matches card for view transition */}
-            {project.icon && iconRegistry[project.icon] && (
-              <div className="relative">
-                <div className="absolute inset-0 blur-2xl opacity-40 bg-foreground/20 scale-150" />
-                <div
-                  className="relative p-6 rounded-2xl border shadow-lg bg-foreground/10 border-foreground/20"
-                  style={{ viewTransitionName: `project-icon-${slug}` }}
-                >
-                  {(() => {
-                    const IconComponent = iconRegistry[project.icon!];
-                    return <IconComponent className="w-12 h-12 text-foreground/80" />;
-                  })()}
-                </div>
-              </div>
-            )}
+        {/* Hero section with background - all projects get this */}
+        <div className="relative bg-gradient-to-b from-foreground/5 via-foreground/[0.02] to-transparent pb-8">
+          {/* Grid pattern overlay */}
+          <div
+            className="absolute inset-0 opacity-[0.03]"
+            style={{
+              backgroundImage: 'linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)',
+              backgroundSize: '20px 20px'
+            }}
+          />
 
-            {/* Grid pattern overlay */}
-            <div
-              className="absolute inset-0 opacity-[0.03]"
-              style={{
-                backgroundImage: 'linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)',
-                backgroundSize: '20px 20px'
-              }}
-            />
-
-            {/* Back link - positioned in hero */}
-            <TransitionLink
-              to="/projects"
-              className="absolute top-4 left-4 md:top-6 md:left-6 inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-background/80 backdrop-blur-sm border border-border text-muted-foreground hover:text-foreground hover:bg-background transition-colors"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              <span className="text-sm">All projects</span>
-            </TransitionLink>
-          </div>
-        )}
-
-        <div className={cn(
-          'container mx-auto px-4',
-          project.fullWidth ? 'py-6' : 'pb-12'
-        )}>
-          <div className={cn(!project.fullWidth && 'max-w-4xl mx-auto')}>
-            {/* Back link for fullWidth projects (no hero) */}
-            {project.fullWidth && (
+          <div className="relative container mx-auto px-4 pt-6">
+            <div className={cn(!project.fullWidth && 'max-w-4xl mx-auto')}>
+              {/* Back link */}
               <TransitionLink
                 to="/projects"
-                className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-4"
+                className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors mb-6"
               >
                 <ArrowLeft className="w-4 h-4" />
                 All projects
               </TransitionLink>
-            )}
 
-            {/* Project header */}
-            <header className="mb-4">
-              <div className="flex flex-wrap items-center gap-3 mb-2">
-                <h1
-                  className={cn(
-                    'font-bold',
-                    project.fullWidth ? 'text-2xl md:text-3xl' : 'text-3xl md:text-4xl'
+              {/* Project header */}
+              <header className="mb-6">
+                <div className="flex items-start gap-4 mb-3">
+                  {/* Icon - inline with title for view transition */}
+                  {project.icon && iconRegistry[project.icon] && (
+                    <div
+                      className="shrink-0 p-3 rounded-xl border shadow-sm bg-foreground/10 border-foreground/20"
+                      style={{ viewTransitionName: `project-icon-${slug}` }}
+                    >
+                      {(() => {
+                        const IconComponent = iconRegistry[project.icon!];
+                        return <IconComponent className="w-8 h-8 text-foreground/80" />;
+                      })()}
+                    </div>
                   )}
-                  style={{ viewTransitionName: `project-title-${slug}` }}
-                >
-                  {project.title}
-                </h1>
-                <Badge variant={statusVariants[project.status]}>
-                  {statusLabels[project.status]}
-                </Badge>
-              </div>
-              <p className={cn(
-                'text-muted-foreground mb-3',
-                project.fullWidth ? 'text-base' : 'text-lg'
-              )}>
-                {project.description}
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {project.tags.map((tag) => (
-                  <Badge key={tag} variant="outline">
-                    {tag}
-                  </Badge>
-                ))}
-              </div>
-            </header>
+                  <div className="flex flex-wrap items-center gap-3 pt-1">
+                    <h1
+                      className={cn(
+                        'font-bold',
+                        project.fullWidth ? 'text-2xl md:text-3xl' : 'text-3xl md:text-4xl'
+                      )}
+                      style={{ viewTransitionName: `project-title-${slug}` }}
+                    >
+                      {project.title}
+                    </h1>
+                    <Badge variant={statusVariants[project.status]}>
+                      {statusLabels[project.status]}
+                    </Badge>
+                  </div>
+                </div>
+                <p className={cn(
+                  'text-muted-foreground mb-3',
+                  project.fullWidth ? 'text-base' : 'text-lg'
+                )}>
+                  {project.description}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {project.tags.map((tag) => (
+                    <Badge key={tag} variant="outline">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              </header>
+            </div>
+          </div>
+        </div>
+
+        <div className={cn(
+          'container mx-auto px-4',
+          project.fullWidth ? 'pb-6' : 'pb-12'
+        )}>
+          <div className={cn(!project.fullWidth && 'max-w-4xl mx-auto')}>
 
             {/* Project component */}
             <div className={cn(


### PR DESCRIPTION
## Summary
- Move project icon to left of title on project detail pages
- Add gradient + grid background to Projects listing page header
- Add gradient + grid background to project detail page header
- Consistent visual language across all project pages

## Test plan
- [ ] Verify icon appears inline with title on project detail page
- [ ] Verify gradient + grid background on /projects
- [ ] Verify gradient + grid background on /projects/:slug
- [ ] Test view transitions still work when navigating between pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)