### PR TITLE
feat(cli-playground): UX improvements for Learn mode

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://dylanbochman.com/</loc>
-    <lastmod>2026-01-17</lastmod>
+    <lastmod>2026-01-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/blog</loc>
-    <lastmod>2026-01-17</lastmod>
+    <lastmod>2026-01-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects</loc>
-    <lastmod>2026-01-17</lastmod>
+    <lastmod>2026-01-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/components/projects/cli-playground/LearnHeader.tsx
+++ b/src/components/projects/cli-playground/LearnHeader.tsx
@@ -1,5 +1,10 @@
 import { Target } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import type { Tool, ToolPreset } from './types';
 
 interface LearnHeaderProps {
@@ -9,34 +14,34 @@ interface LearnHeaderProps {
 }
 
 // Command hints for each tool - concepts to explore
-const COMMAND_HINTS: Record<Tool, { label: string; command: string; tip: string }[]> = {
+const COMMAND_HINTS: Record<Tool, { label: string; command: string }[]> = {
   jq: [
-    { label: '.field', command: '.name', tip: 'Access a field' },
-    { label: 'keys', command: 'keys', tip: 'Get object keys' },
-    { label: '.[]', command: '.[]', tip: 'Iterate array' },
-    { label: 'select()', command: '.[] | select(.age > 25)', tip: 'Filter items' },
+    { label: 'Get field', command: '.name' },
+    { label: 'List keys', command: 'keys' },
+    { label: 'Iterate array', command: '.[]' },
+    { label: 'Filter items', command: '.[] | select(.age > 25)' },
   ],
   grep: [
-    { label: 'pattern', command: 'error', tip: 'Match text' },
-    { label: '-i', command: '-i error', tip: 'Case insensitive' },
-    { label: '-v', command: '-v error', tip: 'Invert match' },
-    { label: '-n', command: '-n error', tip: 'Line numbers' },
+    { label: 'Match text', command: 'error' },
+    { label: 'Ignore case', command: '-i error' },
+    { label: 'Invert match', command: '-v error' },
+    { label: 'Line numbers', command: '-n error' },
   ],
   sed: [
-    { label: 's/a/b/', command: 's/old/new/', tip: 'Replace first' },
-    { label: 's/a/b/g', command: 's/old/new/g', tip: 'Replace all' },
-    { label: '/p/d', command: '/^#/d', tip: 'Delete lines' },
+    { label: 'Replace first', command: 's/old/new/' },
+    { label: 'Replace all', command: 's/old/new/g' },
+    { label: 'Delete lines', command: '/^#/d' },
   ],
   awk: [
-    { label: '$1', command: '{print $1}', tip: 'First column' },
-    { label: '$1,$2', command: '{print $1, $2}', tip: 'Multiple columns' },
-    { label: 'sum', command: '{sum += $2} END {print sum}', tip: 'Sum values' },
+    { label: 'First column', command: '{print $1}' },
+    { label: 'Multiple cols', command: '{print $1, $2}' },
+    { label: 'Sum values', command: '{sum += $2} END {print sum}' },
   ],
   kubectl: [
-    { label: 'pods', command: 'get pods', tip: 'List pods and status' },
-    { label: 'describe', command: 'describe pod', tip: 'Full pod details' },
-    { label: 'logs', command: 'logs', tip: 'Container output' },
-    { label: 'events', command: 'get events', tip: 'Recent cluster events' },
+    { label: 'Get pods', command: 'get pods' },
+    { label: 'Describe pod', command: 'describe pod' },
+    { label: 'Tail logs', command: 'logs' },
+    { label: 'Get events', command: 'get events' },
   ],
 };
 
@@ -45,7 +50,7 @@ export function LearnHeader({ tool, preset, onTryCommand }: LearnHeaderProps) {
 
   const baseHints = COMMAND_HINTS[tool];
 
-  // For kubectl, add namespace to commands and customize hints per lesson
+  // For kubectl, add namespace to commands
   const hints = tool === 'kubectl' && preset.namespace
     ? baseHints.map(hint => ({
         ...hint,
@@ -63,28 +68,28 @@ export function LearnHeader({ tool, preset, onTryCommand }: LearnHeaderProps) {
       {/* Goal */}
       <div className="flex items-center gap-2 flex-1 min-w-0">
         <Target className="h-4 w-4 text-blue-500 shrink-0" />
-        <span className="text-sm truncate">{goalText}</span>
-        {tool === 'kubectl' && preset.namespace && (
-          <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono text-muted-foreground shrink-0">
-            ns: {preset.namespace}
-          </code>
-        )}
+        <span className="text-sm">{goalText}</span>
       </div>
 
-      {/* Command chips */}
+      {/* Command chips with tooltips showing exact command */}
       <div className="flex items-center gap-1.5 flex-wrap">
         <span className="text-xs text-muted-foreground mr-1">Try:</span>
         {hints.map((hint) => (
-          <Button
-            key={hint.label}
-            variant="outline"
-            size="sm"
-            className="h-6 px-2 text-xs font-mono"
-            onClick={() => onTryCommand(hint.command)}
-            title={hint.tip}
-          >
-            {hint.label}
-          </Button>
+          <Tooltip key={hint.label}>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={() => onTryCommand(hint.command)}
+              >
+                {hint.label}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <code className="font-mono text-xs">{hint.command}</code>
+            </TooltipContent>
+          </Tooltip>
         ))}
       </div>
     </div>

--- a/src/components/projects/cli-playground/TopBar.tsx
+++ b/src/components/projects/cli-playground/TopBar.tsx
@@ -52,7 +52,7 @@ export function TopBar({
           type="single"
           value={tool}
           onValueChange={(v) => v && onToolChange(v as Tool)}
-          className="bg-muted/50 p-1 rounded-lg"
+          className="bg-zinc-200 dark:bg-zinc-800 p-1 rounded-lg"
         >
           {TOOLS.map((t) => (
             <ToggleGroupItem
@@ -97,7 +97,7 @@ export function TopBar({
           type="single"
           value={mode}
           onValueChange={(v) => v && onModeChange(v as Mode)}
-          className="bg-muted/50 p-1 rounded-lg"
+          className="bg-zinc-200 dark:bg-zinc-800 p-1 rounded-lg"
         >
           <ToggleGroupItem
             value="learn"

--- a/src/components/projects/cli-playground/Workspace.tsx
+++ b/src/components/projects/cli-playground/Workspace.tsx
@@ -11,6 +11,7 @@ interface WorkspaceProps {
   mode: Mode;
   explanation: CommandExplanation | null;
   hideStdin?: boolean;
+  emptyStatePrompt?: string; // Lesson-aware prompt for empty output
   onInputChange: (value: string) => void;
   onTryCommand: (command: string) => void;
 }
@@ -35,6 +36,7 @@ export function Workspace({
   mode,
   explanation,
   hideStdin,
+  emptyStatePrompt,
   onInputChange,
   onTryCommand,
 }: WorkspaceProps) {
@@ -103,7 +105,7 @@ export function Workspace({
                     : 'text-muted-foreground hover:text-foreground'
                 }`}
               >
-                {error ? 'stderr' : 'stdout'}
+                {error ? 'Error' : 'Output'}
               </button>
               <button
                 onClick={() => setActiveTab('explain')}
@@ -118,7 +120,7 @@ export function Workspace({
             </div>
           ) : (
             <span className="text-xs font-medium text-muted-foreground">
-              {error ? 'stderr' : 'stdout'}
+              {error ? 'Error' : 'Output'}
             </span>
           )}
           {effectiveTab === 'output' && (
@@ -155,7 +157,9 @@ export function Workspace({
               ) : output ? (
                 output
               ) : (
-                <span className="text-muted-foreground/50">Output will appear here...</span>
+                <span className="text-muted-foreground/50">
+                  {emptyStatePrompt || 'Output will appear here...'}
+                </span>
               )}
             </pre>
           </div>

--- a/src/components/projects/cli-playground/types.ts
+++ b/src/components/projects/cli-playground/types.ts
@@ -203,7 +203,7 @@ export const TOOL_CONFIGS: Record<Tool, ToolConfig> = {
         command: 'get pods -n payments',
         fixture: 'crashloop',
         namespace: 'payments',
-        objective: 'Identify failing pods and determine root cause',
+        objective: 'Find the CrashLooping pod and confirm why it keeps restarting',
       },
       {
         name: 'ImagePullBackOff',
@@ -212,7 +212,7 @@ export const TOOL_CONFIGS: Record<Tool, ToolConfig> = {
         command: 'get pods -n frontend',
         fixture: 'imagepull',
         namespace: 'frontend',
-        objective: 'Diagnose image pull errors and authentication issues',
+        objective: 'Find the pod stuck pulling its image and identify the exact error',
       },
       {
         name: 'Service Mismatch',
@@ -221,7 +221,7 @@ export const TOOL_CONFIGS: Record<Tool, ToolConfig> = {
         command: 'get svc,endpoints -n api',
         fixture: 'service-mismatch',
         namespace: 'api',
-        objective: 'Find why traffic is not reaching pods',
+        objective: 'Find why the service has no endpoints and fix the selector mismatch',
       },
       {
         name: 'Rollout Regression',
@@ -230,7 +230,7 @@ export const TOOL_CONFIGS: Record<Tool, ToolConfig> = {
         command: 'rollout status deployment/web -n production',
         fixture: 'rollout-regression',
         namespace: 'production',
-        objective: 'Identify regression and perform rollback',
+        objective: 'Identify the failing deployment and roll back to the previous version',
       },
       {
         name: 'Node Pressure',
@@ -239,7 +239,7 @@ export const TOOL_CONFIGS: Record<Tool, ToolConfig> = {
         command: 'get nodes',
         fixture: 'node-pressure',
         namespace: 'default',
-        objective: 'Identify node issues causing pod evictions',
+        objective: 'Find the node under pressure and identify which pods are being evicted',
       },
     ],
   },


### PR DESCRIPTION
## Summary
UX polish for the CLI Tool Playground Learn mode based on feedback - makes the first run feel alive, tightens copy, and improves visual hierarchy.

## Changes

**Auto-run on lesson load**
- Automatically executes default command when lesson loads in Learn mode
- First impression shows real kubectl output immediately

**Objective copy**
- More concrete, action-oriented objectives
- Before: "Identify failing pods and determine root cause"
- After: "Find the CrashLooping pod and confirm why it keeps restarting"

**Command chips**
- Action-oriented labels: "Get pods", "Describe pod", "Tail logs", "Get events"
- Tooltips show exact command that will be inserted
- Removed monospace font for better readability

**Namespace handling**
- Removed redundant `ns: payments` pill from objective bar
- Single source of truth: `-n` flag in command

**Output panel**
- Changed "stdout/stderr" labels to "Output/Error" (less developer-y)
- Lesson-aware empty state: "Press ⌘+Enter to get resources in payments"

**Toggle contrast**
- Darker background (`zinc-200`/`zinc-800`) for better selected/unselected contrast

## Test plan
- [ ] Load CLI playground in Learn mode - should auto-run and show output
- [ ] Switch lessons - should auto-run new lesson's command
- [ ] Hover command chips - should show exact command in tooltip
- [ ] Check toggle contrast in light and dark mode

🤖 Generated with [Claude Code](https://claude.ai/code)