### PR TITLE
fix(build): update JS budget and lazy-load Mermaid

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,10 +79,11 @@ jobs:
 
           // Budgets: raw file sizes with ~15% headroom to catch regressions
           // Transfer sizes are ~70% smaller due to gzip compression
+          // Note: Mermaid adds ~2MB for diagram support (flowchart, sequence, etc.)
           const BUDGETS = {
-            totalJS: 2048 * 1024,     // 2MB raw (current ~1.8MB)
-            totalCSS: 110 * 1024,     // 110KB raw (current ~94KB)
-            largestChunk: 450 * 1024, // 450KB raw (current ~400KB)
+            totalJS: 4500 * 1024,     // 4.5MB raw (current ~4.3MB with Mermaid)
+            totalCSS: 110 * 1024,     // 110KB raw (current ~100KB)
+            largestChunk: 500 * 1024, // 500KB raw (current ~480KB)
           };
 
           const distAssets = path.join('dist', 'assets');


### PR DESCRIPTION
## Summary
Fixes build failures caused by JS bundle budget being exceeded after adding Mermaid diagrams.

## Changes
- Increase JS budget from 2MB to 4.5MB to accommodate Mermaid
- Update largest chunk budget from 450KB to 500KB  
- Make Mermaid import dynamic so it only loads when visiting the diagrams page
- Mermaid chunks (~1.5MB) now load on-demand instead of blocking initial page load

## Test Plan
- [ ] Build passes CI budget check
- [ ] Incident Response Diagrams page still renders correctly
- [ ] Mermaid chunks load lazily (check Network tab)

🤖 Generated with [Claude Code](https://claude.ai/code)