### PR TITLE
feat(incident-diagrams): add interactive walkthrough animation

### DIFF
--- a/src/components/projects/incident-command-diagrams/AnimatedMermaidDiagram.tsx
+++ b/src/components/projects/incident-command-diagrams/AnimatedMermaidDiagram.tsx
@@ -454,12 +454,17 @@ export function AnimatedMermaidDiagram({
                       Pause
                     </Button>
                   )}
-                  <Button variant="outline" size="sm" onClick={skipToNext} disabled={isComplete}>
-                    <SkipForward className="h-4 w-4" />
-                  </Button>
-                  <Button variant="outline" size="sm" onClick={reset}>
-                    <RotateCcw className="h-4 w-4" />
-                  </Button>
+                  {/* Hide skip and reset on final node - only show back and replay */}
+                  {!isComplete && (
+                    <>
+                      <Button variant="outline" size="sm" onClick={skipToNext}>
+                        <SkipForward className="h-4 w-4" />
+                      </Button>
+                      <Button variant="outline" size="sm" onClick={reset}>
+                        <RotateCcw className="h-4 w-4" />
+                      </Button>
+                    </>
+                  )}
                 </div>
               )}
             </div>

--- a/src/components/projects/incident-command-diagrams/index.tsx
+++ b/src/components/projects/incident-command-diagrams/index.tsx
@@ -77,7 +77,7 @@ flowchart TD
   K -->|Yes| L[Resolve StatusPage Incident]
   K -->|No| M[Continue mitigation]
   M --> F
-  L --> N[Resolve Internal Incident]
+  L --> N[Incident Resolution]
   click D "#service-owner-paging" "Open Service Owner Paging Path"
   class D jump;
 `,
@@ -106,10 +106,8 @@ flowchart TD
       { id: 'K', label: 'Confirm stability', type: 'decision', branches: [['Stable', 11], ['Not Stable', 5]], description: 'Are we confident the fix is holding?' },
       // 11
       { id: 'L', label: 'Resolve StatusPage Incident', description: 'Mark the external incident as resolved.' },
-      // 12
-      { id: 'M', label: 'Continue mitigation', description: 'Issue resurfaced - return to investigation.' },
-      // 13
-      { id: 'N', label: 'Resolve Internal Incident', description: 'Close out the internal incident ticket.' },
+      // 12 (M is a loop-back node only reachable via "Not Stable" branch to F, not part of main flow)
+      { id: 'N', label: 'Incident Resolution', description: 'Close out the internal incident ticket.' },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Add step-by-step animated walkthrough for incident command diagrams
- Replace static diagrams with interactive walkthrough as the default view

## Changes
- **AnimatedMermaidDiagram.tsx**: New component for animated walkthroughs with:
  - Auto-play animation with configurable speed
  - Play/pause/skip forward/skip back/reset controls
  - Decision nodes that pause for user to choose a path
  - Link nodes that provide navigation to related diagrams
  - Side-by-side layout with diagram on left, context panel on right
  - Sticky context panel that floats with scroll
  - Auto-scroll to center the active node
  - Progress bar and step counter
  
- **index.tsx**: Updated to use animated walkthrough by default
  - Removed walkthrough toggle (now always on)
  - Moved "Copy Mermaid" button inside expandable source section
  - Added link nodes connecting diagrams together

## Test plan
- [x] Navigate to `/projects/incident-command-diagrams`
- [x] Click "Start" or the ready panel to begin walkthrough
- [x] Verify animation steps through nodes with spotlight effect
- [x] Test decision points show branch buttons (e.g., "High Severity" / "Low Severity")
- [x] Test link nodes show "View Details" / "Continue" buttons
- [x] Verify "View Details" navigates to linked diagram tab
- [x] Test back button works on all node types
- [x] Verify last node shows restart icon instead of continue
- [x] Test in both light and dark themes
- [x] Check mobile responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)