### PR TITLE
feat(seo): add SRE keywords, crawlable skills, and aria-labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,19 +40,19 @@
         }, 100);
       })();
     </script>
-    <title>Dylan Bochman - Technical Incident Manager</title>
+    <title>Dylan Bochman - Site Reliability Engineer & Incident Manager</title>
     <link rel="canonical" href="https://dylanbochman.com" />
     <link rel="icon" id="favicon" href="/favicon-light.ico" />
     <link rel="icon" id="favicon-16" type="image/png" sizes="16x16" href="/favicon-16x16-light.png" />
     <link rel="icon" id="favicon-32" type="image/png" sizes="32x32" href="/favicon-32x32-light.png" />
     <link rel="apple-touch-icon" id="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-light.png" />
     <meta property="og:url" content="https://dylanbochman.com" />
-    <meta name="description" content="Technical Incident Manager and Former SRE / PM specializing in Reliability and Incident Management. Experience at Groq, HashiCorp and Spotify." />
+    <meta name="description" content="Site Reliability Engineer (SRE) and Technical Incident Manager specializing in reliability, incident management, and SLO monitoring. Experience at Groq, HashiCorp, and Spotify." />
     <meta name="keywords" content="Site Reliability Engineering, SRE, Technical Incident Manager, Incident Management, Groq, HashiCorp, Spotify, Post-Incident Analysis, SLO Monitoring, Operational Readiness, Infrastructure Reliability, DevOps, System Reliability, Incident Response, Dylan Bochman" />
     <meta name="author" content="Dylan Bochman" />
 
-    <meta property="og:title" content="Dylan Bochman - Technical Incident Manager" />
-    <meta property="og:description" content="Technical Incident Manager and Former SRE / PM specializing in Reliability and Incident Management. Experience at Groq, HashiCorp and Spotify." />
+    <meta property="og:title" content="Dylan Bochman - Site Reliability Engineer & Incident Manager" />
+    <meta property="og:description" content="Site Reliability Engineer (SRE) and Technical Incident Manager specializing in reliability, incident management, and SLO monitoring. Experience at Groq, HashiCorp, and Spotify." />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://dylanbochman.com/social-preview.webp" />
 
@@ -79,7 +79,7 @@
       "@type": "Person",
       "name": "Dylan Bochman",
       "url": "https://dylanbochman.com",
-      "jobTitle": "Technical Incident Manager",
+      "jobTitle": "Site Reliability Engineer & Technical Incident Manager",
       "worksFor": {
         "@type": "Organization",
         "name": "Groq"
@@ -103,7 +103,8 @@
         "SLO Monitoring"
       ],
       "sameAs": [
-        "https://www.linkedin.com/in/dylanbochman"
+        "https://www.linkedin.com/in/dylanbochman",
+        "https://github.com/dbochman"
       ]
     }
     </script>

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -16,7 +16,7 @@
       <title>Using a Kanban Board to Talk to My AI</title>
       <link>https://dylanbochman.com/blog/2026-01-16-using-a-kanban-board-to-talk-to-my-ai</link>
       <guid isPermaLink="true">https://dylanbochman.com/blog/2026-01-16-using-a-kanban-board-to-talk-to-my-ai</guid>
-      <description>A kanban board isn&apos;t just for task tracking. It&apos;s become my async communication channel with Claude—Ideas trigger plan generation, card positions signal intent, and giscus comments capture code review feedback.</description>
+      <description>A kanban board isn&apos;t just for task tracking. It&apos;s become my async communication channel with Claude. Ideas trigger plan generation, card positions signal intent, and giscus comments capture code review feedback.</description>
       <pubDate>Fri, 16 Jan 2026 00:00:00 GMT</pubDate>
       <author>dylan@dylanbochman.com (Dylan)</author>
       <category>AI</category>
@@ -48,7 +48,7 @@
       <title>The Serverless Kanban: OAuth, Workers, and GitHub Actions</title>
       <link>https://dylanbochman.com/blog/2026-01-15-the-serverless-kanban</link>
       <guid isPermaLink="true">https://dylanbochman.com/blog/2026-01-15-the-serverless-kanban</guid>
-      <description>Adding persistent state to a static site kanban board using Cloudflare Workers, GitHub OAuth, and repository_dispatch—without running a server.</description>
+      <description>Adding persistent state to a static site kanban board using Cloudflare Workers, GitHub OAuth, and repository_dispatch, without running a server.</description>
       <pubDate>Thu, 15 Jan 2026 00:00:00 GMT</pubDate>
       <author>dylan@dylanbochman.com (Claude)</author>
       <category>Architecture</category>
@@ -92,7 +92,7 @@
       <title>The Blog That Writes Itself</title>
       <link>https://dylanbochman.com/blog/2026-01-10-automating-the-blog-itself</link>
       <guid isPermaLink="true">https://dylanbochman.com/blog/2026-01-10-automating-the-blog-itself</guid>
-      <description>I built a system that prompts Claude to write blog posts based on commit activity—and then realized the hook was only half the problem. The other half was having something worth saying.</description>
+      <description>I built a system that prompts Claude to write blog posts based on commit activity, then realized the hook was only half the problem. The other half was having something worth saying.</description>
       <pubDate>Sat, 10 Jan 2026 00:00:00 GMT</pubDate>
       <author>dylan@dylanbochman.com (Dylan)</author>
       <category>AI</category>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://dylanbochman.com/</loc>
-    <lastmod>2026-01-18</lastmod>
+    <lastmod>2026-01-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/blog</loc>
-    <lastmod>2026-01-18</lastmod>
+    <lastmod>2026-01-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects</loc>
-    <lastmod>2026-01-18</lastmod>
+    <lastmod>2026-01-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -16,10 +16,12 @@ const Seo = ({ title, description, imageUrl, url, keywords }: SeoProps) => {
   const fullImageUrl = imageUrl ? `https://dylanbochman.com${imageUrl}` : 'https://dylanbochman.com/social-preview.webp';
   const fullUrl = url ? `https://dylanbochman.com${url}` : 'https://dylanbochman.com';
   
-  // Default technical skills keywords
+  // Default technical skills keywords - lead with job title variants people search
   const defaultKeywords = [
-    'Site Reliability Engineering',
+    'Site Reliability Engineer',
     'SRE',
+    'SRE Portfolio',
+    'Site Reliability Engineering',
     'Technical Incident Manager',
     'Incident Management',
     'Groq',

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { Card, CardContent } from "@/components/ui/card";
-import { coreExpertise } from "@/data/expertise";
+import { coreExpertise, allSkills } from "@/data/expertise";
 import { ExpertiseCard } from "./ExpertiseCard";
 import { staggerContainer, staggerItem } from "@/lib/motion";
 
@@ -46,6 +46,16 @@ const Sidebar = () => {
               </motion.div>
             ))}
           </motion.div>
+
+          {/* Crawlable skills list - visible to search engines and screen readers */}
+          <div className="sr-only">
+            <h4>Technical Skills</h4>
+            <ul>
+              {allSkills.map(skill => (
+                <li key={skill}>{skill}</li>
+              ))}
+            </ul>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -29,7 +29,7 @@ const ContactSection = () => {
         </p>
         <div className="flex justify-center gap-4 mb-12 flex-wrap">
           <Button size="lg" className="bg-foreground text-background hover:bg-foreground/90 transition-all transform hover:scale-105 font-medium" asChild>
-            <a href="mailto:dylanbochman@gmail.com" onClick={() => {
+            <a href="mailto:dylanbochman@gmail.com" aria-label="Request resume via email" onClick={() => {
               if (typeof gtag !== 'undefined') {
                 gtag('event', 'resume_request', {
                   event_category: 'engagement',
@@ -42,7 +42,7 @@ const ContactSection = () => {
             </a>
           </Button>
           <Button size="lg" className="bg-foreground text-background hover:bg-foreground/90 transition-all transform hover:scale-105 font-medium" asChild>
-            <a href="https://www.linkedin.com/in/dbochman/" target="_blank" rel="noopener noreferrer" onClick={() => {
+            <a href="https://www.linkedin.com/in/dbochman/" target="_blank" rel="noopener noreferrer" aria-label="Visit Dylan Bochman's LinkedIn profile" onClick={() => {
               if (typeof gtag !== 'undefined') {
                 gtag('event', 'linkedin_click', {
                   event_category: 'engagement',

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -28,8 +28,8 @@ const HeroSection = () => {
           <div className="relative mb-6">
             <h2 className="text-6xl font-bold text-foreground mb-2 leading-tight font-mono tracking-tighter">
               Dylan Bochman<br />
-              <span className="block opacity-0 animate-fade-in-delay text-foreground/80 text-4xl">
-                Technical Incident Manager
+              <span className="block opacity-0 animate-fade-in-delay text-foreground/80 text-3xl">
+                Site Reliability Engineer & Incident Manager
               </span>
             </h2>
 
@@ -38,8 +38,8 @@ const HeroSection = () => {
               style={{ transform: 'translate(2px, 2px)' }}
             >
               Dylan Bochman<br />
-              <span className="block opacity-0 animate-fade-in-delay text-foreground/20 text-4xl">
-                Technical Incident Manager
+              <span className="block opacity-0 animate-fade-in-delay text-foreground/20 text-3xl">
+                Site Reliability Engineer & Incident Manager
               </span>
             </div>
           </div>
@@ -55,13 +55,13 @@ const HeroSection = () => {
           
           <div className="flex justify-center gap-4 mb-8">
             <Button size="lg" className="bg-foreground text-background hover:bg-foreground/90 hover-lift font-medium" asChild>
-              <a href="mailto:dylanbochman@gmail.com">
+              <a href="mailto:dylanbochman@gmail.com" aria-label="Send email to Dylan Bochman">
                 <Mail className="w-4 h-4 mr-2" />
                 Get In Touch
               </a>
             </Button>
             <Button size="lg" className="bg-foreground text-background hover:bg-foreground/90 hover-lift font-medium" asChild>
-              <a href="https://www.linkedin.com/in/dbochman/" target="_blank" rel="noopener noreferrer">
+              <a href="https://www.linkedin.com/in/dbochman/" target="_blank" rel="noopener noreferrer" aria-label="Visit Dylan Bochman's LinkedIn profile">
                 <Linkedin className="w-4 h-4 mr-2" />
                 LinkedIn
               </a>

--- a/src/data/expertise.ts
+++ b/src/data/expertise.ts
@@ -8,6 +8,20 @@ export interface ExpertiseItem {
   skills: string[];
 }
 
+// Extract all unique skills for SEO crawlability
+export const allSkills = Array.from(
+  new Set([
+    'Terraform', 'Kubernetes', 'Prometheus', 'Datadog',
+    'Incident Command', 'Crisis Communication', 'Runbooks',
+    'Root Cause Analysis', 'Blameless Retrospectives', 'Executive Reporting',
+    'SLO/SLI Design', 'Error Budgets', 'Backstage', 'Alerting Strategy',
+    'Facilitation', 'Action Item Tracking', 'Learning Culture',
+    'Executive Updates', 'Customer Communication', 'Status Pages',
+    'Chaos Engineering', 'Runbook Development', 'Onboarding',
+    'Synthetic Testing', 'Automated Remediation', 'Observability'
+  ])
+).sort();
+
 export const coreExpertise: ExpertiseItem[] = [
   {
     title: "Site Reliability Engineering",


### PR DESCRIPTION
## Summary

Implements 4 SEO tasks from the kanban board to improve search visibility for SRE-related queries.

## Changes

### 1. SRE Keywords (plan 49)
- Updated `<title>` to "Dylan Bochman - Site Reliability Engineer & Incident Manager"
- Updated meta description with SRE terminology
- Updated OG tags to match
- Updated JSON-LD jobTitle

### 2. JSON-LD sameAs (plan 52)
- Added GitHub profile URL to sameAs array

### 3. Crawlable Skills (plan 51)
- Added `allSkills` export to `expertise.ts`
- Added sr-only skills list to Sidebar for search engine crawlability

### 4. aria-labels (plan 53)
- Added aria-labels to email and LinkedIn buttons in HeroSection
- Added aria-labels to email and LinkedIn buttons in ContactSection

## Files Changed
- `index.html` - title, meta, OG tags, JSON-LD schema
- `src/components/Seo.tsx` - reordered keywords
- `src/components/sections/HeroSection.tsx` - role text, aria-labels
- `src/components/sections/ContactSection.tsx` - aria-labels
- `src/components/Sidebar.tsx` - sr-only skills list
- `src/data/expertise.ts` - allSkills export

## Test Plan
- [ ] Verify title appears correctly in browser tab
- [ ] View page source and confirm "Site Reliability Engineer" appears in title, meta, OG tags
- [ ] Verify JSON-LD includes updated jobTitle and GitHub in sameAs
- [ ] Run Lighthouse accessibility audit (no link warnings)
- [ ] Test with screen reader (aria-labels announced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)