### PR TITLE
test: update tests for SEO title change and allSkills export

### DIFF
--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -36,7 +36,8 @@ vi.mock('@/data/expertise', () => ({
       companies: ['groq'],
       skills: ['Testing']
     }
-  ]
+  ],
+  allSkills: ['Incident Command', 'Kubernetes', 'Root Cause Analysis', 'SLO Design', 'Terraform', 'Testing']
 }))
 
 // Mock SVG imports

--- a/src/pages/Index.test.tsx
+++ b/src/pages/Index.test.tsx
@@ -21,7 +21,7 @@ describe('Index Page', () => {
     // Check for Hero Section content
     const main = screen.getByRole('main');
     expect(within(main).getAllByText('Dylan Bochman')[0]).toBeInTheDocument();
-    expect(within(main).getAllByText('Technical Incident Manager')[0]).toBeInTheDocument();
+    expect(within(main).getAllByText('Site Reliability Engineer & Incident Manager')[0]).toBeInTheDocument();
     expect(screen.getByText((content, node) => {
       if (!node) return false;
       const hasText = (n) => /Specializing in.*Reliability, Resilience, and Incident Management/.test(n.textContent || '');


### PR DESCRIPTION
## Summary

Fix test failures caused by SEO improvements in PR #174.

## Changes

1. **Index.test.tsx** - Updated expected title from "Technical Incident Manager" to "Site Reliability Engineer & Incident Manager"

2. **Sidebar.test.tsx** - Added `allSkills` to the expertise mock to match the new export

## Test Plan
- [x] All 158 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)