### PR TITLE
fix: clean Codex output and fix visual regression issues

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -75,11 +75,30 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Extract only the findings from Codex output (skip verbose exec logs)
+          # The summary starts with a line beginning with "codex" (lowercase)
+          awk '
+            /^codex$/ { capture=1 }
+            capture { print }
+          ' review_output.txt > findings.txt
+
+          # If no findings extracted, check if there were no issues
+          if [ ! -s findings.txt ]; then
+            if grep -q "no issues" review_output.txt 2>/dev/null; then
+              echo "No issues found." > findings.txt
+            else
+              echo "Review completed - see workflow logs for details." > findings.txt
+            fi
+          fi
+
+          # Clean up file paths (remove /home/runner/work/.../... prefix)
+          sed -i 's|/home/runner/work/[^/]*/[^/]*/||g' findings.txt
+
           # Build comment with header
           {
             echo "## 🤖 Codex Review"
             echo ""
-            cat review_output.txt
+            cat findings.txt
             echo ""
             echo "---"
             echo "<sub>Automated review by OpenAI Codex • Skip by adding \`[skip-review]\` to PR title</sub>"

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          # For workflow_run, use the deployed commit; for workflow_dispatch, use current ref
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
 
   // Snapshot output directory
   snapshotDir: './tests/e2e/snapshots',
-  snapshotPathTemplate: '{snapshotDir}/{testFilePath}/{arg}{ext}',
+  snapshotPathTemplate: '{snapshotDir}/{testFileName}/{arg}{ext}',
 
   use: {
     // Base URL for tests


### PR DESCRIPTION
## Summary
Filters Codex review comments to show only findings and fixes the visual regression workflow issues identified in PR #177.

## Changes
- **Codex review output filtering**: Parse output to extract only the summary and findings, skipping verbose exec logs and metadata
- **Path cleanup**: Remove `/home/runner/work/.../...` prefix from file paths in findings
- **Checkout ref fix (P1)**: Use `workflow_run.head_sha` for workflow_run events to test the actual deployed commit
- **Snapshot path fix (P2)**: Use `{testFileName}` instead of `{testFilePath}` to match committed baseline layout

## Test plan
- [x] Codex review on this PR should show clean output without verbose logs
- [x] Visual regression workflow should find baselines correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)