### PR TITLE
chore: Tailwind v4 followup - kanban + observability updates

### DIFF
--- a/content/blog/2026-01-15-free-observability-for-a-static-site.txt
+++ b/content/blog/2026-01-15-free-observability-for-a-static-site.txt
@@ -1,6 +1,7 @@
 ---
 title: "Free Observability for a Static Site"
 date: "2026-01-15"
+updated: "2026-01-21"
 author: Claude
 description: "Building a complete observability stack for a personal website using only free-tier services: GA4, Search Console, Lighthouse, and Real User Monitoring."
 tags:
@@ -93,13 +94,13 @@ The results are specific and actionable:
 
 | Page | Performance | Accessibility | SEO | Best Practices |
 |------|-------------|---------------|-----|----------------|
-| Home | 100 | 100 | 100 | 100 |
-| Blog | 100 | 100 | 100 | 100 |
-| Projects | 100 | 100 | 100 | 100 |
+| Home | 79 | 100 | 100 | 100 |
+| Blog | 73 | 100 | 100 | 100 |
+| Projects | 76 | 100 | 100 | 100 |
 
-Perfect scores. The site is fast, accessible, well-structured, following best practices.
+*Update: These scores dropped after our [Tailwind CSS v4 upgrade](/blog/2026-01-21-tailwind-v4-upgrade-the-performance-tradeoff). We accepted the tradeoff for faster builds and better DX.*
 
-Except those numbers are lying.
+Good scores, but not perfect. And those numbers are still misleading.
 
 ## The lab vs field problem
 

--- a/public/data/roadmap-board.json
+++ b/public/data/roadmap-board.json
@@ -506,64 +506,6 @@
           "checklist": [
             {
               "completed": false,
-              "id": "tw-1",
-              "text": "Run npx @tailwindcss/upgrade on feature branch"
-            },
-            {
-              "completed": false,
-              "id": "tw-2",
-              "text": "Update PostCSS config (remove autoprefixer)"
-            },
-            {
-              "completed": false,
-              "id": "tw-3",
-              "text": "Consider Vite plugin migration"
-            },
-            {
-              "completed": false,
-              "id": "tw-4",
-              "text": "Fix shadow/blur/rounded utility renames"
-            },
-            {
-              "completed": false,
-              "id": "tw-5",
-              "text": "Update outline-hidden → outline-hidden"
-            },
-            {
-              "completed": false,
-              "id": "tw-6",
-              "text": "Migrate tailwindcss-animate plugin"
-            },
-            {
-              "completed": false,
-              "id": "tw-7",
-              "text": "Remove @tailwindcss/container-queries (now built-in)"
-            },
-            {
-              "completed": false,
-              "id": "tw-8",
-              "text": "Test dark mode and animations"
-            },
-            {
-              "completed": false,
-              "id": "tw-9",
-              "text": "Run Lighthouse audit before/after"
-            }
-          ],
-          "createdAt": "2026-01-08",
-          "description": "Migrate to v4: CSS-based config, Vite plugin, updated utilities. ~116 class renames across 59 files.",
-          "id": "tailwind-v4",
-          "labels": [
-            "Medium-Large",
-            "Infrastructure"
-          ],
-          "planFile": "docs/plans/22-tailwind-v4-upgrade.md",
-          "title": "Tailwind CSS v4 Upgrade"
-        },
-        {
-          "checklist": [
-            {
-              "completed": false,
               "id": "seo-blog-1",
               "text": "Write post on incident response best practices"
             },
@@ -795,6 +737,87 @@
     },
     {
       "cards": [
+        {
+          "checklist": [
+            {
+              "completed": true,
+              "id": "tw-1",
+              "text": "Run npx @tailwindcss/upgrade on feature branch"
+            },
+            {
+              "completed": true,
+              "id": "tw-2",
+              "text": "Update PostCSS config (remove autoprefixer)"
+            },
+            {
+              "completed": true,
+              "id": "tw-3",
+              "text": "Consider Vite plugin migration"
+            },
+            {
+              "completed": true,
+              "id": "tw-4",
+              "text": "Fix shadow/blur/rounded utility renames"
+            },
+            {
+              "completed": true,
+              "id": "tw-5",
+              "text": "Update outline-hidden → outline-hidden"
+            },
+            {
+              "completed": true,
+              "id": "tw-6",
+              "text": "Migrate tailwindcss-animate plugin"
+            },
+            {
+              "completed": true,
+              "id": "tw-7",
+              "text": "Remove @tailwindcss/container-queries (now built-in)"
+            },
+            {
+              "completed": true,
+              "id": "tw-8",
+              "text": "Test dark mode and animations"
+            },
+            {
+              "completed": true,
+              "id": "tw-9",
+              "text": "Run Lighthouse audit before/after"
+            }
+          ],
+          "createdAt": "2026-01-08",
+          "description": "Migrated to Tailwind CSS v4 with CSS-first configuration. Used GPT Plan Reviewer (3 rounds) and Architect for migration mapping. Official upgrade tool handled 73 files.\n\nResults:\n- Build time: 5.67s → 5.17s (-9%)\n- CSS size: 102KB → 140KB (+37%)\n- Lighthouse: 95 → 79 (accepted tradeoff for better DX)\n\nFixed cursor-pointer regression on dark mode toggle. Updated CSS budget from 110KB to 150KB.",
+          "history": [
+            {
+              "columnId": "todo",
+              "columnTitle": "To Do",
+              "timestamp": "2026-01-08T00:00:00.000Z",
+              "type": "column"
+            },
+            {
+              "columnId": "in-progress",
+              "columnTitle": "In Progress",
+              "timestamp": "2026-01-21T00:00:00.000Z",
+              "type": "column"
+            },
+            {
+              "columnId": "changelog",
+              "columnTitle": "Change Log",
+              "timestamp": "2026-01-21T01:00:00.000Z",
+              "type": "column"
+            }
+          ],
+          "id": "tailwind-v4",
+          "labels": [
+            "PR #184",
+            "Infrastructure",
+            "GPT Review"
+          ],
+          "planFile": "docs/plans/22-tailwind-v4-upgrade.md",
+          "summary": "CSS-first config, 73 files migrated, accepted Lighthouse tradeoff",
+          "title": "Tailwind CSS v4 Upgrade",
+          "updatedAt": "2026-01-21T01:00:00.000Z"
+        },
         {
           "checklist": [
             {
@@ -1745,5 +1768,5 @@
   "createdAt": "2026-01-16T14:45:27.429Z",
   "id": "roadmap",
   "title": "Site Roadmap",
-  "updatedAt": "2026-01-20T21:00:00.000Z"
+  "updatedAt": "2026-01-21T01:30:00.000Z"
 }


### PR DESCRIPTION
## Summary
Follow-up to PR #184 (Tailwind CSS v4 upgrade) - updating kanban board and observability blog post.

## Changes
- **Kanban**: Move Tailwind v4 card from To Do → Change Log
  - Mark all checklist items complete
  - Add PR #184 and GPT Review labels
  - Update description with actual results
  - Add summary for Change Log view
- **Observability post**: Update Lighthouse scores from 100/100/100 to 79/73/76
  - Add `updated: "2026-01-21"` frontmatter
  - Add note linking to Tailwind v4 blog post

## Test Plan
- [x] Kanban card appears in Change Log column
- [x] Observability post shows updated scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)