### PR TITLE
ci: optimize workflows with caching and fix condition

### DIFF
--- a/.github/workflows/console-check.yml
+++ b/.github/workflows/console-check.yml
@@ -33,8 +33,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Wait for deployment to be live
         run: |

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   lighthouse:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary

Two workflow optimizations:

### 1. console-check.yml: Add Playwright browser caching

Matches the caching pattern used in `pr-checks.yml` and `deploy.yml`. Should save ~30-60s per run by reusing cached browsers instead of downloading fresh each time.

### 2. lighthouse.yml: Fix job condition for push events

The workflow has a `push` trigger for UI-related paths but the job's `if` condition didn't include it, so push-triggered runs would be skipped. Added `github.event_name == 'push'` to the condition.

## Test Plan

- [ ] Verify console-check runs with cache hit after first run
- [ ] Verify lighthouse runs when UI files are pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)