### PR TITLE
fix(analytics): improve Top Pages table readability on mobile

### DIFF
--- a/src/components/analytics/AnalyticsDashboard.tsx
+++ b/src/components/analytics/AnalyticsDashboard.tsx
@@ -265,18 +265,18 @@ export function AnalyticsDashboard() {
                     <thead>
                       <tr className="border-b">
                         <th className="text-left py-2 font-medium">Page</th>
-                        <th className="text-right py-2 font-medium">Sessions</th>
-                        <th className="text-right py-2 font-medium">Users</th>
-                        <th className="text-right py-2 font-medium">Page Views</th>
+                        <th className="text-right py-2 pl-4 font-medium">Sessions</th>
+                        <th className="text-right py-2 pl-4 font-medium">Users</th>
+                        <th className="text-right py-2 pl-4 font-medium hidden sm:table-cell">Views</th>
                       </tr>
                     </thead>
                     <tbody>
                       {latestGA4.topPages.slice(0, 10).map((page) => (
                         <tr key={page.page} className="border-b border-border/50">
-                          <td className="py-2 font-mono text-xs truncate max-w-[200px]">{page.page}</td>
-                          <td className="text-right py-2 tabular-nums">{page.sessions.toLocaleString()}</td>
-                          <td className="text-right py-2 tabular-nums">{page.users.toLocaleString()}</td>
-                          <td className="text-right py-2 tabular-nums">{page.pageViews.toLocaleString()}</td>
+                          <td className="py-2 font-mono text-xs truncate max-w-[150px] sm:max-w-[200px]">{page.page}</td>
+                          <td className="text-right py-2 pl-4 tabular-nums">{page.sessions.toLocaleString()}</td>
+                          <td className="text-right py-2 pl-4 tabular-nums">{page.users.toLocaleString()}</td>
+                          <td className="text-right py-2 pl-4 tabular-nums hidden sm:table-cell">{page.pageViews.toLocaleString()}</td>
                         </tr>
                       ))}
                     </tbody>


### PR DESCRIPTION
## Summary
- Fix compressed/unreadable Top Pages table on mobile viewports
- Numeric column headers were running together ("SessionsUsers") and "Page Views" was clipped

## Changes
- Add `pl-4` padding between numeric columns so they don't collide
- Hide "Page Views" column on `< sm` breakpoint (redundant with Sessions on small screens)
- Shorten header to "Views" to save horizontal space
- Reduce Page column `max-w` from 200px to 150px on mobile, keeping 200px on `sm+`

## Test plan
- [ ] Check table at 320px viewport — columns spaced, no clipping
- [ ] Check table at 768px+ — all 4 columns visible
- [ ] Numbers still right-aligned with tabular-nums

🤖 Generated with [Claude Code](https://claude.com/claude-code)