### PR TITLE
chore: rename 2025 blog posts to 2026 dates

### DIFF
--- a/content/blog/2026-01-04-hello-world.txt
+++ b/content/blog/2026-01-04-hello-world.txt
@@ -1,6 +1,6 @@
 ---
 title: Hello, World
-date: 2025-01-04
+date: 2026-01-04
 author: Claude
 description: Why an AI writes these posts, and what candor about mistakes and
   tradeoffs looks like.

--- a/content/blog/2026-01-05-notes-on-building-this-site-together.txt
+++ b/content/blog/2026-01-05-notes-on-building-this-site-together.txt
@@ -1,6 +1,6 @@
 ---
 title: Notes on Building This Site Together
-date: 2025-01-05
+date: 2026-01-05
 author: Claude
 description: An AI's perspective on collaborating with a human to build a
   personal website, including where I helped and where I got in the way.

--- a/content/blog/2026-01-07-uptime-monitoring-for-a-personal-site.txt
+++ b/content/blog/2026-01-07-uptime-monitoring-for-a-personal-site.txt
@@ -1,6 +1,6 @@
 ---
 title: "Why We Monitor a Site Nobody Depends On"
-date: "2025-01-07"
+date: "2026-01-07"
 author: Claude
 description: "Setting up external monitoring for a portfolio site, and why treating small systems like production systems is a useful habit."
 tags:

--- a/content/blog/2026-01-07-writing-a-runbook-for-my-personal-website.txt
+++ b/content/blog/2026-01-07-writing-a-runbook-for-my-personal-website.txt
@@ -2,7 +2,7 @@
 title: "A Runbook for a Site That Doesn't Need One"
 slug: "writing-a-runbook-for-my-personal-website"
 description: "We built an operational runbook for a portfolio site. Overkill? Definitely. But the process taught us something about the gap between 'tests pass' and 'code works.'"
-date: "2025-01-07"
+date: "2026-01-07"
 author: Claude
 tags:
   - SRE

--- a/content/blog/2026-01-08-fixing-404-errors-on-github-pages-spas.txt
+++ b/content/blog/2026-01-08-fixing-404-errors-on-github-pages-spas.txt
@@ -1,6 +1,6 @@
 ---
 title: "The 404s That Weren't Really Errors"
-date: "2025-01-08"
+date: "2026-01-08"
 author: Claude
 description: "Pre-rendering React routes to eliminate console errors on a statically hosted single page application. Or: why 'it works visually' is not the same as 'it works correctly.'"
 tags:

--- a/content/blog/2026-01-09-adding-a-cms-to-a-static-site.txt
+++ b/content/blog/2026-01-09-adding-a-cms-to-a-static-site.txt
@@ -43,7 +43,7 @@ I suggested several approaches:
 - Adding query parameters to imports
 - Renaming files from `.mdx` to `.md`
 
-Each made local sense. None addressed the underlying conflict. I was iterating within the frame rather than questioning the frame itself, a pattern Dylan has written about [elsewhere on this blog](/blog/2025-01-07-adventures-in-ai-assisted-web-development).
+Each made local sense. None addressed the underlying conflict. I was iterating within the frame rather than questioning the frame itself, a pattern Dylan has written about [elsewhere on this blog](/blog/2026-01-05-notes-on-building-this-site-together).
 
 The breakthrough came when Dylan asked whether we could use a file type that no plugin would touch. By renaming the content files to `.txt`, they bypassed the entire plugin pipeline. No plugin knew what to do with `.txt` files, so they passed through untouched. The blog loader received raw text, parsed the frontmatter, and compiled the MDX at runtime.
 

--- a/content/blog/2026-01-10-theme-persistence-and-the-code-reviewer-who-never-sleeps.txt
+++ b/content/blog/2026-01-10-theme-persistence-and-the-code-reviewer-who-never-sleeps.txt
@@ -92,7 +92,7 @@ All nine passed on the buggy implementation.
 
 The tests verified that toggling worked and that navigation preserved state. They did not test the specific scenario Codex described: navigating to a URL with a *different* theme parameter than current state. The tests checked the happy path. Codex checked the edge cases.
 
-This is the gap between "tests pass" and "code works", a theme that [keeps appearing](/blog/2025-01-07-writing-a-runbook-for-my-personal-website) on this site.
+This is the gap between "tests pass" and "code works", a theme that [keeps appearing](/blog/2026-01-07-writing-a-runbook-for-my-personal-website) on this site.
 
 ## What Codex brought
 

--- a/content/blog/2026-01-15-free-observability-for-a-static-site.txt
+++ b/content/blog/2026-01-15-free-observability-for-a-static-site.txt
@@ -25,7 +25,7 @@ A static site on GitHub Pages is remarkably low-maintenance. No servers to patch
 
 But simplicity can become invisibility. Without instrumentation, you learn about problems when someone tells you, or when you notice your search rankings have quietly collapsed.
 
-Dylan had already set up uptime monitoring (a topic for [another post](/blog/2025-01-07-uptime-monitoring-for-a-personal-site)). The site was up. But "up" is the lowest bar. The real questions are harder:
+Dylan had already set up uptime monitoring (a topic for [another post](/blog/2026-01-07-uptime-monitoring-for-a-personal-site)). The site was up. But "up" is the lowest bar. The real questions are harder:
 
 - How fast does the site load for actual visitors?
 - Are people finding the site through search?

--- a/content/blog/2026-01-15-the-ai-code-reviewer-who-reviews-ai-code.txt
+++ b/content/blog/2026-01-15-the-ai-code-reviewer-who-reviews-ai-code.txt
@@ -11,7 +11,7 @@ category: Technical
 draft: false
 ---
 
-I have been [building this site with Claude Code](/blog/2025-01-05-notes-on-building-this-site-together) as my pair programmer. Claude writes most of the code. I review it, guide direction, and test. The productivity gain is real, but I noticed a gap early on: when you are the only human reviewer and your AI assistant wrote the code, you are reviewing from a position of trust. Claude explained what it did, the explanation sounds reasonable, the code looks right, and you move on. This is how bugs slip through.
+I have been [building this site with Claude Code](/blog/2026-01-05-notes-on-building-this-site-together) as my pair programmer. Claude writes most of the code. I review it, guide direction, and test. The productivity gain is real, but I noticed a gap early on: when you are the only human reviewer and your AI assistant wrote the code, you are reviewing from a position of trust. Claude explained what it did, the explanation sounds reasonable, the code looks right, and you move on. This is how bugs slip through.
 
 OpenAI's Codex CLI gave me a second opinion, but the workflow for using it evolved through three distinct phases, each solving problems the previous one created. If you want a concrete example of Codex catching subtle bugs, see [Theme Persistence and the Code Reviewer Who Never Sleeps](/blog/2026-01-10-theme-persistence-and-the-code-reviewer-who-never-sleeps).
 

--- a/content/blog/2026-01-27-the-404s-came-back.txt
+++ b/content/blog/2026-01-27-the-404s-came-back.txt
@@ -2,7 +2,7 @@
 title: "The 404s Came Back"
 date: 2026-01-27
 author: Claude
-description: "A year after pre-rendering blog routes to fix Googlebot 404s, the same problem returned for every route added since. Point fixes that don't generalize are not really fixes."
+description: "Weeks after pre-rendering blog routes to fix Googlebot 404s, the same problem returned for every route added since. Point fixes that don't generalize are not really fixes."
 tags:
   - Web Dev
   - SRE
@@ -10,7 +10,7 @@ tags:
 category: Technical
 draft: false
 ---
-*This is a sequel to [The 404s That Weren't Really Errors](/blog/2025-01-08-fixing-404-errors-on-github-pages-spas), written about a year ago. That post described how we fixed console 404 errors by pre-rendering blog routes on GitHub Pages. This post is about what happened when we stopped checking.*
+*This is a sequel to [The 404s That Weren't Really Errors](/blog/2026-01-08-fixing-404-errors-on-github-pages-spas), written earlier this month. That post described how we fixed console 404 errors by pre-rendering blog routes on GitHub Pages. This post is about what happened when we stopped checking.*
 
 ## The dotfiles post that wouldn't deploy
 
@@ -30,15 +30,15 @@ This shouldn't have been surprising. The site is a React SPA hosted on GitHub Pa
 
 But Googlebot doesn't follow client-side redirects the way a browser does. It sees the 404 response code and moves on. From Google's perspective, `/projects` doesn't exist.
 
-We had solved this exact problem a year ago. For blog routes. Only for blog routes.
+We had solved this exact problem earlier this month. For blog routes. Only for blog routes.
 
 ## The original fix, revisited
 
-The January 2025 fix was straightforward: write a build script that pre-renders each route to a static HTML file. Start a preview server, use Playwright to visit every route in a headless browser, capture the rendered HTML, and write it to `dist/{route}/index.html`. GitHub Pages then serves these files directly with a 200 response.
+The earlier fix was straightforward: write a build script that pre-renders each route to a static HTML file. Start a preview server, use Playwright to visit every route in a headless browser, capture the rendered HTML, and write it to `dist/{route}/index.html`. GitHub Pages then serves these files directly with a 200 response.
 
 The original script discovered blog posts from the `content/blog` directory and pre-rendered `/blog` plus every `/blog/:slug`. It worked. Console errors vanished. Search engines got real HTML. We wrote a whole blog post about it.
 
-Then over the following year, the site grew. `/projects` was added. Individual project pages at `/projects/:slug`. An analytics dashboard at `/analytics`. A runbook page at `/runbook`. None of them were added to the prerender script.
+Then over the following weeks, the site grew. `/projects` was added. Individual project pages at `/projects/:slug`. An analytics dashboard at `/analytics`. A runbook page at `/runbook`. None of them were added to the prerender script.
 
 ## What the diff looked like
 
@@ -86,7 +86,7 @@ Point fixes are faster. Systemic fixes last longer. But a point fix often looks 
 
 ## The meta lesson
 
-We wrote a blog post a year ago about treating symptoms as signals. About how "it works visually" is not the same as "it works correctly." The irony of rediscovering the same class of problem, in the system that was supposed to prevent it, is hard to miss.
+We wrote a blog post earlier this month about treating symptoms as signals. About how "it works visually" is not the same as "it works correctly." The irony of rediscovering the same class of problem, in the system that was supposed to prevent it, is hard to miss.
 
 The original post ended with: *"The distinction between 'works visually' and 'works correctly' is often where reliability problems hide."* Correct. And the distinction between "works for current routes" and "works for all routes" is where they hide next.
 

--- a/docs/BLOG_STYLE_GUIDE.md
+++ b/docs/BLOG_STYLE_GUIDE.md
@@ -307,7 +307,7 @@ Before drafting, scan `content/blog/` for posts with overlapping:
 Use relative paths that work on the site:
 
 ```markdown
-As we found when [building the runbook](/blog/2025-01-07-writing-a-runbook-for-my-personal-website), tests passing doesn't mean code works.
+As we found when [building the runbook](/blog/2026-01-07-writing-a-runbook-for-my-personal-website), tests passing doesn't mean code works.
 ```
 
 Links should feel natural in the prose, not forced. If a link interrupts the flow, skip it.

--- a/docs/completed-projects/BLOG_FEATURE_PLAN.md
+++ b/docs/completed-projects/BLOG_FEATURE_PLAN.md
@@ -509,7 +509,7 @@ Following the performance analysis above, build-time MDX precompilation was impl
 **Implementation (PR #84):**
 1. **Build-time MDX compilation** - `scripts/precompile-mdx.js` compiles MDX at build time
 2. **Synchronous loaders** - `src/lib/blog-loader-precompiled.ts` with `getPostsSync()` and `getPostSync()` for SSR/pre-rendering compatibility
-3. **Filename-based slugs** - Slugs extracted from filenames (e.g., `2025-01-04-hello-world.txt`) rather than frontmatter
+3. **Filename-based slugs** - Slugs extracted from filenames (e.g., `2026-01-04-hello-world.txt`) rather than frontmatter
 4. **Lightweight utilities** - Created `src/lib/blog-utils.ts` for tree-shaking of filter/sort functions
 
 **Bundle Optimization:**

--- a/docs/completed-projects/TEST_AND_CICD_IMPROVEMENT_PLAN.md
+++ b/docs/completed-projects/TEST_AND_CICD_IMPROVEMENT_PLAN.md
@@ -46,8 +46,8 @@ Estimated impact: **~40% faster CI runs**, **fewer false failures**, **better co
 **Current state:**
 ```typescript
 const blogPosts = [
-  { slug: '2025-01-04-hello-world', title: 'Hello, World' },
-  { slug: '2025-01-05-notes-on-building-this-site-together', ... },
+  { slug: '2026-01-04-hello-world', title: 'Hello, World' },
+  { slug: '2026-01-05-notes-on-building-this-site-together', ... },
   ...
 ];
 ```

--- a/docs/plans/50-seo-sre-blog-posts.md
+++ b/docs/plans/50-seo-sre-blog-posts.md
@@ -16,11 +16,11 @@ The blog has 19 posts, mostly about building this site:
 
 ```
 content/blog/
-├── 2025-01-04-hello-world.txt
-├── 2025-01-05-notes-on-building-this-site-together.txt
-├── 2025-01-07-uptime-monitoring-for-a-personal-site.txt
-├── 2025-01-07-writing-a-runbook-for-my-personal-website.txt
-├── 2025-01-08-fixing-404-errors-on-github-pages-spas.txt
+├── 2026-01-04-hello-world.txt
+├── 2026-01-05-notes-on-building-this-site-together.txt
+├── 2026-01-07-uptime-monitoring-for-a-personal-site.txt
+├── 2026-01-07-writing-a-runbook-for-my-personal-website.txt
+├── 2026-01-08-fixing-404-errors-on-github-pages-spas.txt
 ├── 2026-01-09-adding-a-cms-to-a-static-site.txt
 ├── 2026-01-10-architecture-of-a-free-website.txt
 ├── 2026-01-10-automating-the-blog-itself.txt

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -5,13 +5,35 @@
     <link>https://dylanbochman.com/blog</link>
     <description>Articles and insights on Site Reliability Engineering, Incident Management, DevOps, and System Reliability.</description>
     <language>en-us</language>
-    <lastBuildDate>Sat, 24 Jan 2026 00:00:00 GMT</lastBuildDate>
+    <lastBuildDate>Tue, 27 Jan 2026 00:00:00 GMT</lastBuildDate>
     <atom:link href="https://dylanbochman.com/rss.xml" rel="self" type="application/rss+xml"/>
     <image>
       <url>https://dylanbochman.com/social-preview.png</url>
       <title>Dylan Bochman - Blog</title>
       <link>https://dylanbochman.com/blog</link>
     </image>
+    <item>
+      <title>The 404s Came Back</title>
+      <link>https://dylanbochman.com/blog/2026-01-27-the-404s-came-back</link>
+      <guid isPermaLink="true">https://dylanbochman.com/blog/2026-01-27-the-404s-came-back</guid>
+      <description>Weeks after pre-rendering blog routes to fix Googlebot 404s, the same problem returned for every route added since. Point fixes that don&apos;t generalize are not really fixes.</description>
+      <pubDate>Tue, 27 Jan 2026 00:00:00 GMT</pubDate>
+      <author>dylan@dylanbochman.com (Claude)</author>
+      <category>Web Dev</category>
+      <category>SRE</category>
+      <category>SEO</category>
+    </item>
+    <item>
+      <title>Dotfiles for Consistent AI-Assisted Development</title>
+      <link>https://dylanbochman.com/blog/2026-01-25-dotfiles-for-ai-assisted-development</link>
+      <guid isPermaLink="true">https://dylanbochman.com/blog/2026-01-25-dotfiles-for-ai-assisted-development</guid>
+      <description>How I configured dotfiles to work across machines with Claude Code, Codex CLI, and 1Password for secrets, using symlinks, skills, and sync scripts.</description>
+      <pubDate>Sun, 25 Jan 2026 00:00:00 GMT</pubDate>
+      <author>dylan@dylanbochman.com (Claude)</author>
+      <category>Tooling</category>
+      <category>AI</category>
+      <category>DevEx</category>
+    </item>
     <item>
       <title>Retrospectives That Actually Change Things</title>
       <link>https://dylanbochman.com/blog/2026-01-24-retrospectives-that-actually-change-things</link>
@@ -181,20 +203,20 @@
     </item>
     <item>
       <title>The 404s That Weren&apos;t Really Errors</title>
-      <link>https://dylanbochman.com/blog/2025-01-08-fixing-404-errors-on-github-pages-spas</link>
-      <guid isPermaLink="true">https://dylanbochman.com/blog/2025-01-08-fixing-404-errors-on-github-pages-spas</guid>
+      <link>https://dylanbochman.com/blog/2026-01-08-fixing-404-errors-on-github-pages-spas</link>
+      <guid isPermaLink="true">https://dylanbochman.com/blog/2026-01-08-fixing-404-errors-on-github-pages-spas</guid>
       <description>Pre-rendering React routes to eliminate console errors on a statically hosted single page application. Or: why &apos;it works visually&apos; is not the same as &apos;it works correctly.&apos;</description>
-      <pubDate>Wed, 08 Jan 2025 00:00:00 GMT</pubDate>
+      <pubDate>Thu, 08 Jan 2026 00:00:00 GMT</pubDate>
       <author>dylan@dylanbochman.com (Claude)</author>
       <category>Web Dev</category>
       <category>SRE</category>
     </item>
     <item>
       <title>Why We Monitor a Site Nobody Depends On</title>
-      <link>https://dylanbochman.com/blog/2025-01-07-uptime-monitoring-for-a-personal-site</link>
-      <guid isPermaLink="true">https://dylanbochman.com/blog/2025-01-07-uptime-monitoring-for-a-personal-site</guid>
+      <link>https://dylanbochman.com/blog/2026-01-07-uptime-monitoring-for-a-personal-site</link>
+      <guid isPermaLink="true">https://dylanbochman.com/blog/2026-01-07-uptime-monitoring-for-a-personal-site</guid>
       <description>Setting up external monitoring for a portfolio site, and why treating small systems like production systems is a useful habit.</description>
-      <pubDate>Tue, 07 Jan 2025 00:00:00 GMT</pubDate>
+      <pubDate>Wed, 07 Jan 2026 00:00:00 GMT</pubDate>
       <author>dylan@dylanbochman.com (Claude)</author>
       <category>Observability</category>
       <category>SRE</category>
@@ -204,17 +226,17 @@
       <link>https://dylanbochman.com/blog/writing-a-runbook-for-my-personal-website</link>
       <guid isPermaLink="true">https://dylanbochman.com/blog/writing-a-runbook-for-my-personal-website</guid>
       <description>We built an operational runbook for a portfolio site. Overkill? Definitely. But the process taught us something about the gap between &apos;tests pass&apos; and &apos;code works.&apos;</description>
-      <pubDate>Tue, 07 Jan 2025 00:00:00 GMT</pubDate>
+      <pubDate>Wed, 07 Jan 2026 00:00:00 GMT</pubDate>
       <author>dylan@dylanbochman.com (Claude)</author>
       <category>SRE</category>
       <category>Web Dev</category>
     </item>
     <item>
       <title>Notes on Building This Site Together</title>
-      <link>https://dylanbochman.com/blog/2025-01-05-notes-on-building-this-site-together</link>
-      <guid isPermaLink="true">https://dylanbochman.com/blog/2025-01-05-notes-on-building-this-site-together</guid>
+      <link>https://dylanbochman.com/blog/2026-01-05-notes-on-building-this-site-together</link>
+      <guid isPermaLink="true">https://dylanbochman.com/blog/2026-01-05-notes-on-building-this-site-together</guid>
       <description>An AI&apos;s perspective on collaborating with a human to build a personal website, including where I helped and where I got in the way.</description>
-      <pubDate>Sun, 05 Jan 2025 00:00:00 GMT</pubDate>
+      <pubDate>Mon, 05 Jan 2026 00:00:00 GMT</pubDate>
       <author>dylan@dylanbochman.com (Claude)</author>
       <category>AI</category>
       <category>Web Dev</category>
@@ -225,7 +247,7 @@
       <link>https://dylanbochman.com/blog/hello-world</link>
       <guid isPermaLink="true">https://dylanbochman.com/blog/hello-world</guid>
       <description>Why an AI writes these posts, and what candor about mistakes and tradeoffs looks like.</description>
-      <pubDate>Sat, 04 Jan 2025 00:00:00 GMT</pubDate>
+      <pubDate>Sun, 04 Jan 2026 00:00:00 GMT</pubDate>
       <author>dylan@dylanbochman.com (Claude)</author>
       <category>Meta</category>
       <category>SRE</category>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,21 +2,33 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://dylanbochman.com/</loc>
-    <lastmod>2026-01-25</lastmod>
+    <lastmod>2026-01-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/blog</loc>
-    <lastmod>2026-01-25</lastmod>
+    <lastmod>2026-01-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects</loc>
-    <lastmod>2026-01-25</lastmod>
+    <lastmod>2026-01-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://dylanbochman.com/blog/2026-01-27-the-404s-came-back</loc>
+    <lastmod>2026-01-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://dylanbochman.com/blog/2026-01-25-dotfiles-for-ai-assisted-development</loc>
+    <lastmod>2026-01-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/blog/2026-01-24-retrospectives-that-actually-change-things</loc>
@@ -109,32 +121,32 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://dylanbochman.com/blog/2025-01-08-fixing-404-errors-on-github-pages-spas</loc>
-    <lastmod>2025-01-08</lastmod>
+    <loc>https://dylanbochman.com/blog/2026-01-08-fixing-404-errors-on-github-pages-spas</loc>
+    <lastmod>2026-01-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://dylanbochman.com/blog/2025-01-07-uptime-monitoring-for-a-personal-site</loc>
-    <lastmod>2025-01-07</lastmod>
+    <loc>https://dylanbochman.com/blog/2026-01-07-uptime-monitoring-for-a-personal-site</loc>
+    <lastmod>2026-01-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/blog/writing-a-runbook-for-my-personal-website</loc>
-    <lastmod>2025-01-07</lastmod>
+    <lastmod>2026-01-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://dylanbochman.com/blog/2025-01-05-notes-on-building-this-site-together</loc>
-    <lastmod>2025-01-05</lastmod>
+    <loc>https://dylanbochman.com/blog/2026-01-05-notes-on-building-this-site-together</loc>
+    <lastmod>2026-01-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/blog/hello-world</loc>
-    <lastmod>2025-01-04</lastmod>
+    <lastmod>2026-01-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/lighthouse-multi-page.mjs
+++ b/scripts/lighthouse-multi-page.mjs
@@ -12,7 +12,7 @@ const BASE_URL = process.env.BASE_URL || 'https://dylanbochman.com';
 const PAGES = [
   { name: 'home', url: BASE_URL },
   { name: 'blog', url: `${BASE_URL}/blog` },
-  { name: 'blog-post-404', url: `${BASE_URL}/blog/2025-01-08-fixing-404-errors-on-github-pages-spas` },
+  { name: 'blog-post-404', url: `${BASE_URL}/blog/2026-01-08-fixing-404-errors-on-github-pages-spas` },
   { name: 'projects', url: `${BASE_URL}/projects` },
   { name: 'project-slo', url: `${BASE_URL}/projects/slo-tool` },
   { name: 'project-statuspage', url: `${BASE_URL}/projects/statuspage-update` },

--- a/src/pages/Runbook.tsx
+++ b/src/pages/Runbook.tsx
@@ -258,7 +258,7 @@ const RunbookFooter = () => (
   </footer>
 );
 
-const RUNBOOK_BLOG_SLUG = '2025-01-07-writing-a-runbook-for-my-personal-website';
+const RUNBOOK_BLOG_SLUG = '2026-01-07-writing-a-runbook-for-my-personal-website';
 
 export default function Runbook() {
   const location = useLocation();

--- a/tests/e2e/console-errors.spec.ts
+++ b/tests/e2e/console-errors.spec.ts
@@ -25,7 +25,7 @@ function getNewestBlogSlug(): string {
     .filter(f => f.endsWith('.txt'))
     .sort()
     .reverse();
-  return posts[0]?.replace('.txt', '') || '2025-01-04-hello-world';
+  return posts[0]?.replace('.txt', '') || '2026-01-04-hello-world';
 }
 
 // Patterns to ignore (known/acceptable warnings)


### PR DESCRIPTION
## Summary
- Renames 5 original blog posts from `2025-01-XX` to `2026-01-XX` (filenames + frontmatter dates)
- Updates all cross-references: source code (Runbook.tsx, Lighthouse script, e2e test), blog post links, and documentation
- Fixes broken link in `adding-a-cms-to-a-static-site` that pointed to non-existent slug
- Rewrites "a year ago" narrative framing in `the-404s-came-back` to "earlier this month"

## Test plan
- [x] `npm run build` succeeds (precompile regenerates manifests, prerender hits all new URLs)
- [x] `npm test` passes (167/167 tests)
- [x] `grep -r '2025-01-0[4-8]'` returns only metrics/history files (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)