### PR TITLE
chore(kanban): move fast-path deploy card to changelog

### DIFF
--- a/content/kanban/roadmap/streamline-blog-post-build-deploy-pipeline.md
+++ b/content/kanban/roadmap/streamline-blog-post-build-deploy-pipeline.md
@@ -1,0 +1,19 @@
+---
+id: streamline-blog-post-build-deploy-pipeline
+title: Streamline blog post build/deploy pipeline
+column: changelog
+labels:
+  - Medium
+createdAt: '2026-02-24T23:10:07.895Z'
+updatedAt: '2026-02-24T23:23:14.565Z'
+history:
+  - type: column
+    timestamp: '2026-02-24T23:10:07.895Z'
+    columnId: ideas
+    columnTitle: Ideas
+  - type: column
+    timestamp: '2026-02-24T23:23:14.565Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+Added a `detect-changes` job to `deploy.yml` that classifies pushes as content-only or full-build. Content-only deploys skip Playwright tests, unit tests, Sentry source maps, security audit, and bundle size checks. Deployed in PR #249. Full pipeline: ~10min → Content-only: ~2min.

--- a/src/generated/kanban/manifest.js
+++ b/src/generated/kanban/manifest.js
@@ -13,6 +13,6 @@ export const kanbanManifest = {
   "roadmap": {
     "file": "roadmap.js",
     "title": "Site Roadmap",
-    "cardCount": 58
+    "cardCount": 59
   }
 };

--- a/src/generated/kanban/roadmap.js
+++ b/src/generated/kanban/roadmap.js
@@ -275,6 +275,31 @@ export const board = {
       "title": "Change Log",
       "cards": [
         {
+          "id": "streamline-blog-post-build-deploy-pipeline",
+          "title": "Streamline blog post build/deploy pipeline",
+          "labels": [
+            "Medium"
+          ],
+          "checklist": [],
+          "createdAt": "2026-02-24T23:10:07.895Z",
+          "updatedAt": "2026-02-24T23:23:14.565Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-02-24T23:10:07.895Z",
+              "columnId": "ideas",
+              "columnTitle": "Ideas"
+            },
+            {
+              "type": "column",
+              "timestamp": "2026-02-24T23:23:14.565Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "Added a `detect-changes` job to `deploy.yml` that classifies pushes as content-only or full-build. Content-only deploys skip Playwright tests, unit tests, Sentry source maps, security audit, and bundle size checks. Deployed in PR #249. Full pipeline: ~10min → Content-only: ~2min."
+        },
+        {
           "id": "rework-tablist-mobile-selector",
           "title": "Rework TabList Mobile Selector",
           "summary": "Replace horizontal-scroll/flex-wrap TabList with Select dropdown on mobile (<640px)",


### PR DESCRIPTION
## Summary

- Moves the "Streamline blog post build/deploy pipeline" card from Ideas to Change Log
- Updates card description with implementation details (PR #249)

[skip ci]

🤖 Generated with [Claude Code](https://claude.com/claude-code)