### PR TITLE
fix(ci): use 7-day rolling average for analytics anomaly detection

### DIFF
--- a/.github/workflows/daily-analytics.yml
+++ b/.github/workflows/daily-analytics.yml
@@ -246,17 +246,18 @@ jobs:
           const fs = require('fs');
           const failures = [];
 
-          // Check GA4 data
+          // Check GA4 data using 7-day rolling average to avoid false positives from traffic spikes
           const ga4File = 'docs/metrics/ga4-history.json';
           if (fs.existsSync(ga4File)) {
             const history = JSON.parse(fs.readFileSync(ga4File, 'utf8'));
-            if (history.length >= 2) {
+            if (history.length >= 8) {
               const latest = history[history.length - 1];
-              const previous = history[history.length - 2];
+              const past7 = history.slice(-8, -1);
+              const avgSessions = past7.reduce((sum, e) => sum + e.summary.sessions, 0) / past7.length;
 
-              const sessionsChange = ((latest.summary.sessions - previous.summary.sessions) / previous.summary.sessions) * 100;
-              if (sessionsChange < -30) {
-                failures.push(\`GA4: Sessions dropped by \${Math.abs(Math.round(sessionsChange))}%\`);
+              const sessionsChange = ((latest.summary.sessions - avgSessions) / avgSessions) * 100;
+              if (sessionsChange < -40) {
+                failures.push(\`GA4: Sessions dropped by \${Math.abs(Math.round(sessionsChange))}% vs 7-day avg (\${latest.summary.sessions} vs \${Math.round(avgSessions)})\`);
               }
             }
           }


### PR DESCRIPTION
## Summary
- Replaces day-over-day session comparison with 7-day rolling average
- Raises threshold from -30% to -40% (relative to the rolling avg)
- Includes actual vs average values in the alert message for easier triage

## Problem
The old logic compared consecutive days, so a traffic spike ending (573→318) triggered a -45% alert even though 318 sessions is within the normal baseline (~377). This caused false positive #256.

## Verification
Against March 4 data: 318 sessions vs 454 avg = -29.9% → **would NOT trigger** (correct)

Closes #256

## Test plan
- [x] Verified against historical data that false positive would be avoided
- [x] Threshold still catches genuine drops (>40% below weekly average)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)