### PR TITLE
Automate kanban changelog sync + backfill 2-month gap

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -1,0 +1,95 @@
+name: Sync Changelog
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'content/kanban/**'
+      - 'src/generated/kanban/**'
+  workflow_dispatch:
+    inputs:
+      since:
+        description: 'Commit SHA to backfill from (exclusive). Leave blank to use HEAD~1.'
+        required: false
+        default: ''
+      dry_run:
+        description: 'Print actions without writing'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: sync-changelog
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip-changelog]') && !contains(github.event.head_commit.message, '[skip ci]') }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.DEPLOY_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve commit range
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            SINCE="${{ inputs.since }}"
+            if [ -z "$SINCE" ]; then
+              SINCE="HEAD~1"
+            fi
+          else
+            SINCE="${{ github.event.before }}"
+          fi
+          # Handle initial push / branch creation (all-zeros SHA).
+          if [ "$SINCE" = "0000000000000000000000000000000000000000" ] || [ -z "$SINCE" ]; then
+            echo "Initial push detected — using HEAD~1 as fallback."
+            SINCE="HEAD~1"
+          fi
+          echo "since=$SINCE" >> "$GITHUB_OUTPUT"
+          echo "Using since=$SINCE"
+
+      - name: Sync changelog
+        run: |
+          ARGS="--range=${{ steps.range.outputs.since }}..HEAD"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          node scripts/sync-changelog.js $ARGS
+
+      - name: Precompile kanban
+        if: ${{ inputs.dry_run != 'true' }}
+        run: npm run precompile-kanban
+
+      - name: Commit if changed
+        if: ${{ inputs.dry_run != 'true' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add content/kanban/ src/generated/kanban/
+          if git diff --staged --quiet; then
+            echo "No changelog changes."
+          else
+            # Intentionally NOT using [skip ci]: deploy.yml's detect-changes
+            # job classifies kanban-only changes as content-only and runs the
+            # fast (~2min) deploy path so the new card appears on the site.
+            # The sync-changelog workflow won't re-trigger on this commit
+            # because of the paths-ignore filter above.
+            git commit -m "chore(changelog): sync from recent commits"
+            git push
+          fi

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -28,6 +28,14 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[skip-changelog]') && !contains(github.event.head_commit.message, '[skip ci]') }}
     permissions:
       contents: write
+    env:
+      # Pull user-controlled inputs into env so they reach shell as $VARS
+      # instead of being interpolated into the script body (no command
+      # injection if a malicious value contains shell metacharacters).
+      INPUT_SINCE: ${{ inputs.since }}
+      EVENT_BEFORE: ${{ github.event.before }}
+      EVENT_NAME: ${{ github.event_name }}
+      DRY_RUN: ${{ inputs.dry_run }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -48,36 +56,49 @@ jobs:
       - name: Resolve commit range
         id: range
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            SINCE="${{ inputs.since }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            SINCE="$INPUT_SINCE"
             if [ -z "$SINCE" ]; then
               SINCE="HEAD~1"
             fi
           else
-            SINCE="${{ github.event.before }}"
+            SINCE="$EVENT_BEFORE"
           fi
           # Handle initial push / branch creation (all-zeros SHA).
           if [ "$SINCE" = "0000000000000000000000000000000000000000" ] || [ -z "$SINCE" ]; then
             echo "Initial push detected — using HEAD~1 as fallback."
             SINCE="HEAD~1"
           fi
+          # Reject anything that doesn't look like a safe revision before
+          # passing it into other commands.
+          if ! printf '%s' "$SINCE" | grep -Eq '^[A-Za-z0-9._/~^@-]+$'; then
+            echo "Refusing unsafe SINCE value: $SINCE" >&2
+            exit 1
+          fi
+          # Verify the SHA exists in the repo.
+          if ! git rev-parse --verify "$SINCE^{commit}" >/dev/null 2>&1; then
+            echo "SINCE ($SINCE) is not a valid commit in this repo" >&2
+            exit 1
+          fi
           echo "since=$SINCE" >> "$GITHUB_OUTPUT"
           echo "Using since=$SINCE"
 
       - name: Sync changelog
+        env:
+          SINCE: ${{ steps.range.outputs.since }}
         run: |
-          ARGS="--range=${{ steps.range.outputs.since }}..HEAD"
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            ARGS="$ARGS --dry-run"
+          ARGS=("--range=${SINCE}..HEAD")
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS+=("--dry-run")
           fi
-          node scripts/sync-changelog.js $ARGS
+          node scripts/sync-changelog.js "${ARGS[@]}"
 
       - name: Precompile kanban
-        if: ${{ inputs.dry_run != 'true' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
         run: npm run precompile-kanban
 
       - name: Commit if changed
-        if: ${{ inputs.dry_run != 'true' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,21 @@ gh pr merge --squash --delete-branch
 |------|--------|
 | `[skip ci]` | Skip all GitHub Actions |
 | `[skip-review]` | Skip Codex PR review |
+| `[skip-changelog]` | Skip changelog sync for this commit |
 | `[blog]` | Mark commit as blog-worthy |
 | `[blog:tag]` | Group related commits |
+| `[changelog]` | Force-include in changelog (overrides type filter) |
+
+### Changelog sync
+
+`.github/workflows/sync-changelog.yml` runs on every push to `main` and:
+
+1. Skips noise (dependabot, daily analytics, `chore`/`deps`/`docs`/`ci`/`build`/`style`/`test`/`refactor` without `[changelog]`).
+2. For each remaining commit, looks for an existing roadmap card by `PR #N` label or slug match. If found, moves it to the `changelog` column.
+3. Otherwise, creates a new card directly in `changelog` (only for `feat`/`fix`/`perf`/freeform commits, or anything tagged `[changelog]`).
+4. Bot commits with `[skip ci]` to avoid retriggering workflows.
+
+Backfill or test via `Actions → Sync Changelog → Run workflow` (supports `since` SHA and dry-run).
 
 ## Kanban
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ gh pr merge --squash --delete-branch
 1. Skips noise (dependabot, daily analytics, `chore`/`deps`/`docs`/`ci`/`build`/`style`/`test`/`refactor` without `[changelog]`).
 2. For each remaining commit, looks for an existing roadmap card by `PR #N` label or slug match. If found, moves it to the `changelog` column.
 3. Otherwise, creates a new card directly in `changelog` (only for `feat`/`fix`/`perf`/freeform commits, or anything tagged `[changelog]`).
-4. Bot commits with `[skip ci]` to avoid retriggering workflows.
+4. Bot commits without `[skip ci]` so deploy.yml's content-only fast path runs and the new card lands on the live site within ~2 minutes. The sync workflow itself doesn't re-trigger because of the `paths-ignore` filter on `content/kanban/**` and `src/generated/kanban/**`.
 
 Backfill or test via `Actions → Sync Changelog → Run workflow` (supports `since` SHA and dry-run).
 

--- a/content/kanban/roadmap/2026-02-24-openclaw-the-home-agent.md
+++ b/content/kanban/roadmap/2026-02-24-openclaw-the-home-agent.md
@@ -1,0 +1,15 @@
+---
+id: 2026-02-24-openclaw-the-home-agent
+title: 'Blog: OpenClaw: Experimenting with a personal AI agent'
+column: changelog
+labels:
+  - Blog
+createdAt: '2026-02-24T20:53:10.000Z'
+updatedAt: '2026-02-24T20:53:10.000Z'
+history:
+  - type: column
+    timestamp: '2026-02-24T20:53:10.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+What I learned running an open-source AI agent on a self-hosted Mac Mini. Least privilege, version-controlled config, and the boring plumbing that makes it work.

--- a/content/kanban/roadmap/2026-02-26-echonest-sync-and-the-spotify-api-shakeup.md
+++ b/content/kanban/roadmap/2026-02-26-echonest-sync-and-the-spotify-api-shakeup.md
@@ -1,0 +1,15 @@
+---
+id: 2026-02-26-echonest-sync-and-the-spotify-api-shakeup
+title: 'Blog: EchoNest Sync and the Spotify API Shakeup'
+column: changelog
+labels:
+  - Blog
+createdAt: '2026-02-27T00:26:38.000Z'
+updatedAt: '2026-02-27T00:26:38.000Z'
+history:
+  - type: column
+    timestamp: '2026-02-27T00:26:38.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+We built a desktop sync app for EchoNest. Then Spotify changed its API in ways that made us glad we did.

--- a/content/kanban/roadmap/2026-03-14-watchdogs-and-launchagents.md
+++ b/content/kanban/roadmap/2026-03-14-watchdogs-and-launchagents.md
@@ -1,0 +1,15 @@
+---
+id: 2026-03-14-watchdogs-and-launchagents
+title: 'Blog: Watchdogs and LaunchAgents: Managing Systems That Want to Break'
+column: changelog
+labels:
+  - Blog
+createdAt: '2026-03-14T14:57:07.000Z'
+updatedAt: '2026-03-14T14:57:07.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-14T14:57:07.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+What we learned building a watchdog for BlueBubbles and OpenClaw on a headless Mac Mini. Health monitors that cause the instability they're designed to detect, and how to fix them.

--- a/content/kanban/roadmap/2026-03-31-axios-supply-chain-attack.md
+++ b/content/kanban/roadmap/2026-03-31-axios-supply-chain-attack.md
@@ -1,0 +1,17 @@
+---
+id: 2026-03-31-axios-supply-chain-attack
+title: >-
+  Blog: Anatomy of the axios Supply Chain Attack (and How We Checked Our
+  Machines in 10 Minutes)
+column: changelog
+labels:
+  - Blog
+createdAt: '2026-03-31T11:14:35.000Z'
+updatedAt: '2026-03-31T11:14:35.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-31T11:14:35.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+A compromised npm maintainer account pushed malware into axios. Here's how the attack worked, what it installed, and how we checked our machines in 10 minutes.

--- a/content/kanban/roadmap/_board.md
+++ b/content/kanban/roadmap/_board.md
@@ -2,12 +2,12 @@
 schemaVersion: 1
 id: roadmap
 title: Site Roadmap
-createdAt: "2026-01-16T14:45:27.429Z"
-updatedAt: "2026-01-23T15:59:45.003Z"
+createdAt: '2026-01-16T14:45:27.429Z'
+updatedAt: '2026-04-26T02:20:54.616Z'
 columns:
   - id: ideas
     title: Ideas
-    description: Draft plans and attach them, then move to To Do
+    description: 'Draft plans and attach them, then move to To Do'
   - id: todo
     title: To Do
     description: Planned tasks ready to start

--- a/content/kanban/roadmap/add-60-day-rolling-window-and-remove-redundant-leg.md
+++ b/content/kanban/roadmap/add-60-day-rolling-window-and-remove-redundant-leg.md
@@ -1,0 +1,37 @@
+---
+id: add-60-day-rolling-window-and-remove-redundant-leg
+title: add 60-day rolling window and remove redundant legend
+column: changelog
+labels:
+  - Bugfix
+  - 'PR #270'
+createdAt: '2026-03-28T16:19:25.000Z'
+updatedAt: '2026-03-28T16:19:25.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-28T16:19:25.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+* fix(analytics): add 60-day rolling window and remove redundant legend
+
+- Filter Sessions Over Time, Search Performance, and Blog Traffic charts
+  to show only the last 60 days instead of all historical data
+- Remove redundant legend from Device Breakdown donut chart (labels
+  already display device name and percentage)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* fix: bundle mermaid+dagre together and add missing react-is dep
+
+- Add manualChunks rule to bundle mermaid and dagre into a single chunk,
+  preventing stale hash errors when cached mermaid chunks reference
+  old dagre chunk filenames after redeployment
+- Add react-is as a direct dependency (required by recharts at build
+  time but only present as a transitive dev dependency)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+---------
+
+Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/content/kanban/roadmap/add-7-day-quarantine-hardening-section.md
+++ b/content/kanban/roadmap/add-7-day-quarantine-hardening-section.md
@@ -1,0 +1,16 @@
+---
+id: add-7-day-quarantine-hardening-section
+title: add 7-day quarantine hardening section
+column: changelog
+createdAt: '2026-03-31T13:23:16.000Z'
+updatedAt: '2026-03-31T13:23:16.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-31T13:23:16.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+Added min-release-age=7 (npm) and exclude-newer (uv) as a third
+hardening measure alongside save-exact and version pinning.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/content/kanban/roadmap/add-preinstall-guard-section.md
+++ b/content/kanban/roadmap/add-preinstall-guard-section.md
@@ -1,0 +1,16 @@
+---
+id: add-preinstall-guard-section
+title: add preinstall guard section
+column: changelog
+createdAt: '2026-03-31T13:31:10.000Z'
+updatedAt: '2026-03-31T13:31:10.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-31T13:31:10.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+Documents the npm install blocker that forces npm ci usage,
+closing the gap between having a lockfile and actually using it.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/content/kanban/roadmap/consolidate-tags-remove-8-singletons.md
+++ b/content/kanban/roadmap/consolidate-tags-remove-8-singletons.md
@@ -1,0 +1,21 @@
+---
+id: consolidate-tags-remove-8-singletons
+title: consolidate tags — remove 8 singletons
+column: changelog
+createdAt: '2026-03-31T11:28:33.000Z'
+updatedAt: '2026-03-31T11:28:33.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-31T11:28:33.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+Merged low-use tags into existing ones:
+- Observability, Automation → SRE
+- CMS, SEO, Node.js → Web Dev (or removed)
+- Spotify → Projects (removed)
+- Supply Chain → Security (removed)
+
+21 tags → 13.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/content/kanban/roadmap/deduplicate-anomaly-alerts-for-sustained-trends.md
+++ b/content/kanban/roadmap/deduplicate-anomaly-alerts-for-sustained-trends.md
@@ -1,0 +1,19 @@
+---
+id: deduplicate-anomaly-alerts-for-sustained-trends
+title: deduplicate anomaly alerts for sustained trends
+column: changelog
+labels:
+  - Bugfix
+createdAt: '2026-03-28T15:57:22.000Z'
+updatedAt: '2026-03-28T15:57:22.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-28T15:57:22.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+Instead of creating a new issue every day during a prolonged traffic
+decline, append updates as comments on the most recent open anomaly
+issue (within 3 days). New issues are still created for fresh incidents.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/content/kanban/roadmap/eliminate-ai-slop-patterns-across-24-posts.md
+++ b/content/kanban/roadmap/eliminate-ai-slop-patterns-across-24-posts.md
@@ -1,0 +1,57 @@
+---
+id: eliminate-ai-slop-patterns-across-24-posts
+title: eliminate AI slop patterns across 24 posts
+column: changelog
+labels:
+  - 'PR #272'
+createdAt: '2026-03-28T18:25:48.000Z'
+updatedAt: '2026-03-28T18:25:48.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-28T18:25:48.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+* blog: eliminate AI slop patterns across 24 posts
+
+Run slop-guard (https://github.com/eric-tramel/slop-guard) across all
+blog posts and rewrite flagged patterns. All 30 posts now score >= 81/100
+(up from a low of 8/100).
+
+Changes across all posts:
+- Replaced slop words (reflecting, narrative, leverage, significantly,
+  surprisingly, navigate, collaborative, comprehensive, notable)
+- Rewrote "X, not Y" contrast pairs as direct claims
+- Removed "This is not X. It is Y" setup-resolution patterns
+- Expanded or cut pithy one-liner fragments
+- Converted bold-bullet listicle blocks to prose paragraphs
+- Reduced excessive bullet runs and triadic list cadences
+- Varied repeated phrases
+- Cut slop phrases ("the key insight", "deliberate choice", "feel free to")
+
+All frontmatter, code blocks, React components, internal links, and
+ASCII diagrams preserved unchanged.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* blog: fix writing quality violations from proposed slop-guard rules
+
+Address violations from proposed writing quality rules (eric-tramel/slop-guard#9):
+- "tip of the iceberg" cliche → "symptoms of deeper structural issues"
+- "deep dive" cliche → "full technical breakdown"
+- "best practices" cliche → "web standards"
+- "very" qualifier → cut
+- "wonderful" ecstatic adjective → "disarming"
+- "naturally tried to optimize" (over-explanation + pretentious) → "tried to shrink"
+
+Intentionally kept:
+- "obviously" in echonest-sync (intentional humor about airhorns)
+- "## The Journey" headings (inside code blocks, referencing template name)
+- "subsequent" in theme-persistence (technical term: "subsequent navigation")
+- "rather" in "rather than" comparisons (conjunction, not hedging qualifier)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+---------
+
+Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/content/kanban/roadmap/fix-quarantine-section-min-release-age-not-enforce.md
+++ b/content/kanban/roadmap/fix-quarantine-section-min-release-age-not-enforce.md
@@ -1,0 +1,17 @@
+---
+id: fix-quarantine-section-min-release-age-not-enforce
+title: fix quarantine section — min-release-age not enforced in npm 11
+column: changelog
+createdAt: '2026-03-31T13:26:04.000Z'
+updatedAt: '2026-03-31T13:26:04.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-31T13:26:04.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+npm warns "Unknown user config" for min-release-age, so it's not
+actually protecting anything. Kept uv exclude-newer (which works)
+and noted npm doesn't have an equivalent yet.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/content/kanban/roadmap/harden-openclaw-post-security-posture.md
+++ b/content/kanban/roadmap/harden-openclaw-post-security-posture.md
@@ -1,0 +1,40 @@
+---
+id: harden-openclaw-post-security-posture
+title: harden OpenClaw post security posture
+column: changelog
+labels:
+  - 'PR #248'
+createdAt: '2026-02-24T22:56:10.000Z'
+updatedAt: '2026-02-24T22:56:10.000Z'
+history:
+  - type: column
+    timestamp: '2026-02-24T22:56:10.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+* blog: harden OpenClaw post security posture
+
+- Remove specific locations, chat counts, plist names, exact schedules
+- Generalize infrastructure to "Mac-class device" / "system service"
+- Describe guardrails as principles (least privilege, separate service
+  accounts, out-of-band approval) rather than exact mechanisms
+- Reframe hard parts as lessons learned, not precise failure modes
+- Remove personal schedule details; add consent language for shared data
+- Add monitoring/detection section (weekly activity report, anomaly alerts)
+- Remove GOG_KEYRING_PASSWORD and other implementation specifics
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+
+* blog: humanizer pass on OpenClaw post
+
+- Remove formulaic openers ("The lesson:", "The takeaway:", "The goal")
+- Break up rule-of-three/five feature lists into shorter sentences
+- Rewrite security paragraph from brochure tone to plain language
+- Cut negative parallelism ("not just X, but Y")
+- Vary sentence structure and rhythm throughout
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+
+---------
+
+Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

--- a/content/kanban/roadmap/improve-openclaw-post-intro-and-link.md
+++ b/content/kanban/roadmap/improve-openclaw-post-intro-and-link.md
@@ -1,0 +1,37 @@
+---
+id: improve-openclaw-post-intro-and-link
+title: improve OpenClaw post intro and link
+column: changelog
+labels:
+  - 'PR #247'
+createdAt: '2026-02-24T21:39:52.000Z'
+updatedAt: '2026-02-24T21:39:52.000Z'
+history:
+  - type: column
+    timestamp: '2026-02-24T21:39:52.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+* blog: improve OpenClaw post intro with context and link
+
+- Link OpenClaw to https://openclaw.ai/
+- Frame as exploration of an open-source AI agent framework
+- Add context on what OpenClaw is and why it's notable
+- Fix location: Mac Mini is in the cabin, not apartment
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+
+* blog: reframe OpenClaw post and run humanizer pass
+
+- Reframe as experimentation with safety-first approach
+- Remove camera snapshot section
+- Link OpenClaw to https://openclaw.ai/
+- Fix Mac Mini location (cabin not apartment)
+- Humanizer pass: remove bolded inline headers, reduce AI
+  vocabulary, vary sentence structure, cut promotional tone
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+
+---------
+
+Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

--- a/content/kanban/roadmap/inline-diff-in-codex-review-prompt-to-avoid-sandbo.md
+++ b/content/kanban/roadmap/inline-diff-in-codex-review-prompt-to-avoid-sandbo.md
@@ -1,0 +1,21 @@
+---
+id: inline-diff-in-codex-review-prompt-to-avoid-sandbo
+title: inline diff in codex review prompt to avoid sandbox errors
+column: changelog
+labels:
+  - Bugfix
+  - 'PR #271'
+createdAt: '2026-03-28T16:26:04.000Z'
+updatedAt: '2026-03-28T16:26:04.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-28T16:26:04.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+The Codex CLI read-only sandbox (bwrap) blocks file reads with
+"RTM_NEWADDR: Operation not permitted". Fix by passing the diff
+directly in the prompt instead of writing to pr_diff.txt and
+asking Codex to read it.
+
+Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--- a/content/kanban/roadmap/make-blog-the-first-and-default-tab.md
+++ b/content/kanban/roadmap/make-blog-the-first-and-default-tab.md
@@ -1,0 +1,19 @@
+---
+id: make-blog-the-first-and-default-tab
+title: make Blog the first and default tab
+column: changelog
+labels:
+  - Feature
+createdAt: '2026-04-26T01:39:01.000Z'
+updatedAt: '2026-04-26T01:39:01.000Z'
+history:
+  - type: column
+    timestamp: '2026-04-26T01:39:01.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+Reorders ANALYTICS_TABS so Blog is first and sets it as the initial
+activeTab. Also fixes the Search CTR display (averageCTR is already a
+percentage; the extra *100 was double-scaling it).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

--- a/content/kanban/roadmap/make-security-audit-non-blocking-in-deploy-workflo.md
+++ b/content/kanban/roadmap/make-security-audit-non-blocking-in-deploy-workflo.md
@@ -1,0 +1,23 @@
+---
+id: make-security-audit-non-blocking-in-deploy-workflo
+title: make security audit non-blocking in deploy workflow
+column: changelog
+labels:
+  - Bugfix
+  - 'PR #245'
+createdAt: '2026-02-24T21:24:15.000Z'
+updatedAt: '2026-02-24T21:24:15.000Z'
+history:
+  - type: column
+    timestamp: '2026-02-24T21:24:15.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+The deploy workflow's npm audit step was failing the entire build due to
+transitive dependency vulnerabilities in dev tools (eslint, minimatch, glob).
+These are not exploitable in production.
+
+Aligns with pr-checks.yml which already has continue-on-error: true and
+--omit=dev for the audit step.
+
+Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

--- a/content/kanban/roadmap/refactor-search-console-fetch-and-add-summary-only.md
+++ b/content/kanban/roadmap/refactor-search-console-fetch-and-add-summary-only.md
@@ -1,0 +1,33 @@
+---
+id: refactor-search-console-fetch-and-add-summary-only
+title: refactor Search Console fetch and add summary-only mode
+column: changelog
+labels:
+  - Feature
+createdAt: '2026-04-26T01:46:01.000Z'
+updatedAt: '2026-04-26T01:46:01.000Z'
+history:
+  - type: column
+    timestamp: '2026-04-26T01:46:01.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+- Split Search Console query into two calls: an authoritative
+  no-dimension summary and a dimensional rows fetch. Previously the
+  summary was derived by summing rows, which under-counted clicks/
+  impressions because the row response is capped and aggregated by
+  (query, page) — a single page can split across many rows.
+- Replace ad-hoc reductions with summarizeRows / aggregateRows /
+  weightedAveragePosition helpers; impression-weighted positions
+  replace simple averages.
+- Make the daily history write idempotent (update existing date entry
+  instead of appending a duplicate).
+- Add --update-summary-only mode that re-reads the latest history
+  entry and rewrites docs/metrics/latest.json, preserving the original
+  timestamp. The daily workflow now invokes this after fetch-ga4-data.js
+  so the GA4 step's latest.json overwrite doesn't drop fresh Search
+  Console numbers.
+- updateMetricsSummary now takes a lastCheck override so the summary-
+  only path doesn't bump the timestamp to "now".
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

--- a/content/kanban/roadmap/rework-blog-analytics-dashboard.md
+++ b/content/kanban/roadmap/rework-blog-analytics-dashboard.md
@@ -1,0 +1,38 @@
+---
+id: rework-blog-analytics-dashboard
+title: rework blog analytics dashboard
+column: changelog
+labels:
+  - Feature
+  - 'PR #246'
+createdAt: '2026-02-24T21:33:28.000Z'
+updatedAt: '2026-02-24T21:33:28.000Z'
+history:
+  - type: column
+    timestamp: '2026-02-24T21:33:28.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+* feat(analytics): rework blog analytics dashboard
+
+- Add all-time leaderboard aggregating GA4 history across all entries
+- Fix slug matching for renamed posts via alias map + year normalization
+- Replace single-line blog traffic chart with stacked area (top 5 posts)
+- Replace avg reading time metric with all-time views; add WoW trend
+- Switch tag breakdown to all-time data; remove sparse category pie chart
+- Trim 7d table to top 5, streamline columns
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+
+* fix(analytics): address Codex review feedback
+
+- Remove risky partial substring matching in slug resolver to prevent
+  silent data misattribution; add min key length guard (>=10 chars)
+- Use Date.getTime() for firstSeen/lastSeen comparisons instead of
+  string comparison to handle non-ISO date formats safely
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+
+---------
+
+Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

--- a/content/kanban/roadmap/tweak-wording-in-watchdogs-post.md
+++ b/content/kanban/roadmap/tweak-wording-in-watchdogs-post.md
@@ -1,0 +1,13 @@
+---
+id: tweak-wording-in-watchdogs-post
+title: tweak wording in watchdogs post
+column: changelog
+createdAt: '2026-03-14T15:15:46.000Z'
+updatedAt: '2026-03-14T15:15:46.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-14T15:15:46.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

--- a/content/kanban/roadmap/use-7-day-rolling-average-for-analytics-anomaly-de.md
+++ b/content/kanban/roadmap/use-7-day-rolling-average-for-analytics-anomaly-de.md
@@ -1,0 +1,24 @@
+---
+id: use-7-day-rolling-average-for-analytics-anomaly-de
+title: use 7-day rolling average for analytics anomaly detection
+column: changelog
+labels:
+  - Bugfix
+  - 'PR #258'
+createdAt: '2026-03-07T00:50:55.000Z'
+updatedAt: '2026-03-07T00:50:55.000Z'
+history:
+  - type: column
+    timestamp: '2026-03-07T00:50:55.000Z'
+    columnId: changelog
+    columnTitle: Change Log
+---
+The previous day-over-day comparison triggered false positives when traffic
+returned to baseline after a spike (e.g. 573→318 = -45%, but 318 is normal).
+
+Now compares against the 7-day rolling average with a -40% threshold, which
+is more resilient to natural traffic fluctuations.
+
+Closes #256
+
+Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "kanban:move": "node scripts/kanban-cli.js move",
     "kanban:list": "node scripts/kanban-cli.js list",
     "kanban:sync": "node scripts/kanban-cli.js sync",
+    "changelog:sync": "node scripts/sync-changelog.js",
     "copy-metrics": "node scripts/copy-metrics-to-public.js",
     "build:content": "node scripts/copy-metrics-to-public.js && tsx scripts/precompile-mdx.ts && node scripts/precompile-kanban.js && tsx scripts/generate-feeds.ts && node scripts/validate-projects.mjs && node scripts/generate-og-images.mjs",
     "build:vite": "vite build",

--- a/scripts/precompile-kanban.js
+++ b/scripts/precompile-kanban.js
@@ -161,7 +161,7 @@ async function processBoard(boardDir) {
   // Validate board metadata
   const boardResult = KanbanBoardMetaSchema.safeParse(boardMeta);
   if (!boardResult.success) {
-    stats.errors.push(...formatZodErrors(boardResult.error.errors, `${boardId}/_board.md`));
+    stats.errors.push(...formatZodErrors(boardResult.error.issues, `${boardId}/_board.md`));
     return null;
   }
 
@@ -183,7 +183,7 @@ async function processBoard(boardDir) {
     // Validate card frontmatter
     const cardResult = KanbanCardFrontmatterSchema.safeParse(frontmatter);
     if (!cardResult.success) {
-      stats.errors.push(...formatZodErrors(cardResult.error.errors, `${boardId}/${file}`));
+      stats.errors.push(...formatZodErrors(cardResult.error.issues, `${boardId}/${file}`));
       continue;
     }
 

--- a/scripts/sync-changelog.js
+++ b/scripts/sync-changelog.js
@@ -20,7 +20,7 @@
  * Exits 0 on success even when no actions are taken.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { existsSync } from 'fs';
 import { mkdir, readdir, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
@@ -65,26 +65,47 @@ function slugify(title) {
     .slice(0, 50);
 }
 
-function git(cmd) {
-  return execSync(`git ${cmd}`, { encoding: 'utf-8' }).trim();
+function git(args) {
+  // execFileSync with an argv array — no shell interpolation, so user-provided
+  // SHAs/ranges from workflow_dispatch can't expand into command injection.
+  return execFileSync('git', args, { encoding: 'utf-8' }).trim();
+}
+
+// Validate a string looks like a git revision/range. Allows SHAs, refs,
+// `a..b`, `a...b`, `HEAD`, `HEAD~N`, etc. Rejects shell metacharacters.
+function assertSafeRevish(value, label) {
+  if (typeof value !== 'string' || !value) {
+    throw new Error(`${label}: missing value`);
+  }
+  if (!/^[A-Za-z0-9._/~^@\-]+(\.{2,3}[A-Za-z0-9._/~^@\-]+)?$/.test(value)) {
+    throw new Error(`${label}: refusing to use unsafe value ${JSON.stringify(value)}`);
+  }
+  return value;
 }
 
 function resolveCommitRange(opts) {
-  if (opts.commits) return opts.commits.split(',').filter(Boolean);
+  if (opts.commits) {
+    return opts.commits
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => assertSafeRevish(s, 'commits'));
+  }
 
   let range;
-  if (opts.range) range = opts.range;
-  else if (opts.since) range = `${opts.since}..HEAD`;
+  if (opts.range) range = assertSafeRevish(opts.range, 'range');
+  else if (opts.since) range = `${assertSafeRevish(opts.since, 'since')}..HEAD`;
   else range = 'HEAD~1..HEAD';
 
-  const out = git(`log --format=%H --no-merges ${range}`);
+  const out = git(['log', '--format=%H', '--no-merges', range]);
   return out.split('\n').filter(Boolean);
 }
 
 function getCommitInfo(sha) {
+  assertSafeRevish(sha, 'sha');
   // %an = author name, %ae = author email, %s = subject, %b = body, %aI = author date ISO
   const fmt = '%an%x09%ae%x09%aI%x09%s%x1e%b';
-  const out = execSync(`git log -1 --format=${JSON.stringify(fmt)} ${sha}`, { encoding: 'utf-8' });
+  const out = execFileSync('git', ['log', '-1', `--format=${fmt}`, sha], { encoding: 'utf-8' });
   const [meta, body = ''] = out.split('\x1e');
   const [authorName, authorEmail, rawDate, subject] = meta.split('\t');
   // Normalize to UTC ISO so the kanban schema's date validator (which
@@ -96,22 +117,18 @@ function getCommitInfo(sha) {
 // Lazily-built map: historical-blog-path → current-slug. Populated on first
 // call by walking each current blog post's --follow history backward.
 let _blogRenameMap = null;
-function getBlogRenameMap() {
+async function getBlogRenameMap() {
   if (_blogRenameMap) return _blogRenameMap;
   _blogRenameMap = new Map();
   try {
-    const currentFiles = execSync('ls content/blog/*.txt 2>/dev/null', { encoding: 'utf-8' })
-      .trim()
-      .split('\n')
-      .filter(Boolean);
-    for (const currentPath of currentFiles) {
+    const entries = await readdir('./content/blog', { withFileTypes: true });
+    const blogFiles = entries
+      .filter((e) => e.isFile() && e.name.endsWith('.txt'))
+      .map((e) => `content/blog/${e.name}`);
+    for (const currentPath of blogFiles) {
       const slug = currentPath.replace(/^content\/blog\//, '').replace(/\.txt$/, '');
       try {
-        const paths = execSync(
-          `git log --follow --format= --name-only -- "${currentPath}"`,
-          { encoding: 'utf-8' }
-        )
-          .trim()
+        const paths = git(['log', '--follow', '--format=', '--name-only', '--', currentPath])
           .split('\n')
           .filter(Boolean);
         for (const p of new Set(paths)) {
@@ -127,27 +144,25 @@ function getBlogRenameMap() {
   return _blogRenameMap;
 }
 
-function resolveCurrentBlogSlug(originalSlug) {
+async function resolveCurrentBlogSlug(originalSlug) {
   const file = `content/blog/${originalSlug}.txt`;
   if (existsSync(file)) return originalSlug;
-  const map = getBlogRenameMap();
+  const map = await getBlogRenameMap();
   return map.get(file) || originalSlug;
 }
 
-function getAddedBlogPosts(sha) {
+async function getAddedBlogPosts(sha) {
   // List files added in this commit under content/blog/*.txt
+  assertSafeRevish(sha, 'sha');
   try {
     // -M detects renames so a rename isn't counted as an add.
-    const out = execSync(
-      `git diff-tree --no-commit-id --name-only --diff-filter=A -M -r ${sha}`,
-      { encoding: 'utf-8' }
-    ).trim();
+    const out = git(['diff-tree', '--no-commit-id', '--name-only', '--diff-filter=A', '-M', '-r', sha]);
     if (!out) return [];
-    return out
+    const slugs = out
       .split('\n')
       .filter((f) => /^content\/blog\/[^/]+\.txt$/.test(f))
-      .map((f) => f.replace(/^content\/blog\//, '').replace(/\.txt$/, ''))
-      .map(resolveCurrentBlogSlug);
+      .map((f) => f.replace(/^content\/blog\//, '').replace(/\.txt$/, ''));
+    return Promise.all(slugs.map(resolveCurrentBlogSlug));
   } catch {
     return [];
   }
@@ -165,6 +180,15 @@ function extractPrNumber(subject) {
   return m ? parseInt(m[1], 10) : null;
 }
 
+function hasHardSkipFlag(commit) {
+  // Skips that should bypass everything, including blog-post detection.
+  const text = `${commit.subject}\n${commit.body}`;
+  if (/\[skip[- ]?changelog\]/i.test(text)) return 'flag:skip-changelog';
+  if (/\[skip ci\]/i.test(text)) return 'flag:skip-ci';
+  if (/^chore\(changelog\)/i.test(commit.subject)) return 'self-commit';
+  return null;
+}
+
 function classifyCommit(commit) {
   const { authorName, authorEmail, subject, body } = commit;
   const text = `${subject}\n${body}`;
@@ -172,14 +196,12 @@ function classifyCommit(commit) {
   if (authorName === 'dependabot[bot]' || authorEmail.includes('dependabot')) {
     return { action: 'skip', reason: 'dependabot' };
   }
-  if (/\[skip[- ]?changelog\]/i.test(text) || /\[skip ci\]/i.test(text)) {
-    return { action: 'skip', reason: 'flag' };
+  const hardSkip = hasHardSkipFlag(commit);
+  if (hardSkip) {
+    return { action: 'skip', reason: hardSkip };
   }
   if (/^chore:\s*daily analytics/i.test(subject) || /^chore:\s*weekly/i.test(subject)) {
     return { action: 'skip', reason: 'automated-update' };
-  }
-  if (/^chore\(changelog\)/i.test(subject)) {
-    return { action: 'skip', reason: 'self-commit' };
   }
 
   const conv = parseConventional(subject);
@@ -367,8 +389,15 @@ async function main() {
     const commit = getCommitInfo(sha);
 
     // Blog posts: any commit that adds a content/blog/*.txt file gets a card
-    // per added post, regardless of commit type or skip rules.
-    const addedPosts = getAddedBlogPosts(sha);
+    // per added post, regardless of commit type — except when the commit
+    // carries an explicit hard-skip flag ([skip-changelog], [skip ci], or is
+    // a chore(changelog) self-commit).
+    const hardSkip = hasHardSkipFlag(commit);
+    if (hardSkip) {
+      actions.push({ sha, subject: commit.subject, action: 'skip', reason: hardSkip });
+      continue;
+    }
+    const addedPosts = await getAddedBlogPosts(sha);
     if (addedPosts.length > 0) {
       for (const slug of addedPosts) {
         if (cardsById.has(slug)) {

--- a/scripts/sync-changelog.js
+++ b/scripts/sync-changelog.js
@@ -1,0 +1,474 @@
+#!/usr/bin/env node
+/**
+ * Sync recent git commits into the kanban changelog column.
+ *
+ * Hybrid behavior:
+ *   1. If a commit matches an existing card (by `PR #N` label or slug-equals-id),
+ *      move that card to the `changelog` column.
+ *   2. Otherwise, if the commit is `feat:`, `fix:`, `perf:`, or carries a
+ *      `[changelog]` tag, create a new card directly in `changelog`.
+ *   3. Everything else (chore/deps/docs/ci/style/test/refactor without flag,
+ *      dependabot, daily analytics, [skip-changelog]) is ignored.
+ *
+ * Usage:
+ *   node scripts/sync-changelog.js --range=<sha1>..<sha2>      (preferred)
+ *   node scripts/sync-changelog.js --since=<sha>               (sha..HEAD)
+ *   node scripts/sync-changelog.js --commits=<sha1>,<sha2>,... (explicit list)
+ *   node scripts/sync-changelog.js --dry-run                   (print, don't write)
+ *   node scripts/sync-changelog.js --board=roadmap             (default: roadmap)
+ *
+ * Exits 0 on success even when no actions are taken.
+ */
+
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { mkdir, readdir, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+import matter from 'gray-matter';
+
+const CONTENT_DIR = './content/kanban';
+const TARGET_COLUMN = 'changelog';
+
+const SKIPPED_TYPES = new Set(['chore', 'deps', 'docs', 'ci', 'build', 'style', 'test', 'refactor']);
+const NEW_CARD_TYPES = new Set(['feat', 'fix', 'perf']);
+
+const TYPE_LABEL = {
+  feat: 'Feature',
+  fix: 'Bugfix',
+  perf: 'Performance',
+};
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const out = { board: 'roadmap', dryRun: false };
+  for (const arg of args) {
+    if (arg === '--dry-run') out.dryRun = true;
+    else if (arg.startsWith('--')) {
+      const [k, v] = arg.slice(2).split('=');
+      out[k] = v ?? true;
+    }
+  }
+  return out;
+}
+
+function toISOString(value) {
+  if (!value) return value;
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+}
+
+function slugify(title) {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 50);
+}
+
+function git(cmd) {
+  return execSync(`git ${cmd}`, { encoding: 'utf-8' }).trim();
+}
+
+function resolveCommitRange(opts) {
+  if (opts.commits) return opts.commits.split(',').filter(Boolean);
+
+  let range;
+  if (opts.range) range = opts.range;
+  else if (opts.since) range = `${opts.since}..HEAD`;
+  else range = 'HEAD~1..HEAD';
+
+  const out = git(`log --format=%H --no-merges ${range}`);
+  return out.split('\n').filter(Boolean);
+}
+
+function getCommitInfo(sha) {
+  // %an = author name, %ae = author email, %s = subject, %b = body, %aI = author date ISO
+  const fmt = '%an%x09%ae%x09%aI%x09%s%x1e%b';
+  const out = execSync(`git log -1 --format=${JSON.stringify(fmt)} ${sha}`, { encoding: 'utf-8' });
+  const [meta, body = ''] = out.split('\x1e');
+  const [authorName, authorEmail, rawDate, subject] = meta.split('\t');
+  // Normalize to UTC ISO so the kanban schema's date validator (which
+  // requires `Z` or no offset) accepts it. %aI includes a timezone offset.
+  const date = new Date(rawDate).toISOString();
+  return { sha, authorName, authorEmail, date, subject, body: body.trim() };
+}
+
+// Lazily-built map: historical-blog-path → current-slug. Populated on first
+// call by walking each current blog post's --follow history backward.
+let _blogRenameMap = null;
+function getBlogRenameMap() {
+  if (_blogRenameMap) return _blogRenameMap;
+  _blogRenameMap = new Map();
+  try {
+    const currentFiles = execSync('ls content/blog/*.txt 2>/dev/null', { encoding: 'utf-8' })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    for (const currentPath of currentFiles) {
+      const slug = currentPath.replace(/^content\/blog\//, '').replace(/\.txt$/, '');
+      try {
+        const paths = execSync(
+          `git log --follow --format= --name-only -- "${currentPath}"`,
+          { encoding: 'utf-8' }
+        )
+          .trim()
+          .split('\n')
+          .filter(Boolean);
+        for (const p of new Set(paths)) {
+          if (/^content\/blog\/[^/]+\.txt$/.test(p)) _blogRenameMap.set(p, slug);
+        }
+      } catch {
+        /* skip this file */
+      }
+    }
+  } catch {
+    /* empty map */
+  }
+  return _blogRenameMap;
+}
+
+function resolveCurrentBlogSlug(originalSlug) {
+  const file = `content/blog/${originalSlug}.txt`;
+  if (existsSync(file)) return originalSlug;
+  const map = getBlogRenameMap();
+  return map.get(file) || originalSlug;
+}
+
+function getAddedBlogPosts(sha) {
+  // List files added in this commit under content/blog/*.txt
+  try {
+    // -M detects renames so a rename isn't counted as an add.
+    const out = execSync(
+      `git diff-tree --no-commit-id --name-only --diff-filter=A -M -r ${sha}`,
+      { encoding: 'utf-8' }
+    ).trim();
+    if (!out) return [];
+    return out
+      .split('\n')
+      .filter((f) => /^content\/blog\/[^/]+\.txt$/.test(f))
+      .map((f) => f.replace(/^content\/blog\//, '').replace(/\.txt$/, ''))
+      .map(resolveCurrentBlogSlug);
+  } catch {
+    return [];
+  }
+}
+
+function parseConventional(subject) {
+  // type(scope)!: subject  →  { type, scope, breaking, message }
+  const m = subject.match(/^([a-z]+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
+  if (!m) return null;
+  return { type: m[1], scope: m[2] || null, breaking: !!m[3], message: m[4] };
+}
+
+function extractPrNumber(subject) {
+  const m = subject.match(/\(#(\d+)\)\s*$/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+function classifyCommit(commit) {
+  const { authorName, authorEmail, subject, body } = commit;
+  const text = `${subject}\n${body}`;
+
+  if (authorName === 'dependabot[bot]' || authorEmail.includes('dependabot')) {
+    return { action: 'skip', reason: 'dependabot' };
+  }
+  if (/\[skip[- ]?changelog\]/i.test(text) || /\[skip ci\]/i.test(text)) {
+    return { action: 'skip', reason: 'flag' };
+  }
+  if (/^chore:\s*daily analytics/i.test(subject) || /^chore:\s*weekly/i.test(subject)) {
+    return { action: 'skip', reason: 'automated-update' };
+  }
+  if (/^chore\(changelog\)/i.test(subject)) {
+    return { action: 'skip', reason: 'self-commit' };
+  }
+
+  const conv = parseConventional(subject);
+  const hasFlag = /\[changelog\]/i.test(text);
+
+  // Always try to match existing cards first, regardless of type.
+  // The classifier here only decides what to do when no match is found.
+  if (!conv) {
+    return { action: 'try-match-only', conv: null, hasFlag };
+  }
+
+  if (NEW_CARD_TYPES.has(conv.type) || hasFlag) {
+    return { action: 'try-match-or-create', conv, hasFlag };
+  }
+  if (SKIPPED_TYPES.has(conv.type) && !hasFlag) {
+    return { action: 'try-match-only', conv, hasFlag };
+  }
+  return { action: 'try-match-or-create', conv, hasFlag };
+}
+
+async function loadBoardMeta(boardId) {
+  const boardPath = join(CONTENT_DIR, boardId, '_board.md');
+  if (!existsSync(boardPath)) throw new Error(`Board not found: ${boardId}`);
+  const content = await readFile(boardPath, 'utf-8');
+  const { data } = matter(content);
+  return data;
+}
+
+async function loadCards(boardId) {
+  const boardDir = join(CONTENT_DIR, boardId);
+  const files = await readdir(boardDir);
+  const cards = [];
+  for (const file of files) {
+    if (!file.endsWith('.md') || file === '_board.md') continue;
+    const content = await readFile(join(boardDir, file), 'utf-8');
+    const { data, content: body } = matter(content);
+    cards.push({ ...data, description: body.trim() || undefined, _file: file });
+  }
+  return cards;
+}
+
+function findMatchingCard(cards, commit, conv) {
+  const prNum = extractPrNumber(commit.subject);
+  if (prNum) {
+    const byPr = cards.find((c) =>
+      (c.labels || []).some((l) => new RegExp(`^PR #${prNum}\\b`).test(l))
+    );
+    if (byPr) return { card: byPr, via: `PR #${prNum} label` };
+  }
+
+  // Fall back to slug match against subject (with conventional prefix stripped).
+  const subjectForSlug = conv ? conv.message : commit.subject;
+  // Strip trailing PR suffix before slugifying.
+  const cleaned = subjectForSlug.replace(/\s*\(#\d+\)\s*$/, '').trim();
+  const slug = slugify(cleaned);
+  if (slug) {
+    const byId = cards.find((c) => c.id === slug);
+    if (byId) return { card: byId, via: 'slug match' };
+  }
+  return null;
+}
+
+async function saveCardMarkdown(boardId, card) {
+  const boardDir = join(CONTENT_DIR, boardId);
+  if (!existsSync(boardDir)) await mkdir(boardDir, { recursive: true });
+
+  const fm = {
+    id: card.id,
+    title: card.title,
+    column: card.column,
+  };
+  if (card.summary) fm.summary = card.summary;
+  if (card.labels?.length) fm.labels = card.labels;
+  if (card.checklist?.length) fm.checklist = card.checklist;
+  if (card.planFile) fm.planFile = card.planFile;
+  if (card.color) fm.color = card.color;
+  if (card.prStatus) fm.prStatus = card.prStatus;
+  if (card.archivedAt) fm.archivedAt = toISOString(card.archivedAt);
+  if (card.archiveReason) fm.archiveReason = card.archiveReason;
+  fm.createdAt = toISOString(card.createdAt) || new Date().toISOString();
+  if (card.updatedAt) fm.updatedAt = toISOString(card.updatedAt);
+  if (card.history?.length) {
+    fm.history = card.history.map((h) => ({ ...h, timestamp: toISOString(h.timestamp) }));
+  }
+
+  const file = join(boardDir, `${card.id}.md`);
+  await writeFile(file, matter.stringify(card.description || '', fm));
+  return file;
+}
+
+async function buildBlogPostCard(slug, commit, columnTitle) {
+  const file = join('./content/blog', `${slug}.txt`);
+  let title = slug;
+  let description = '';
+  if (existsSync(file)) {
+    try {
+      const content = await readFile(file, 'utf-8');
+      const { data } = matter(content);
+      if (data.title) title = data.title;
+      if (data.description) description = data.description;
+    } catch {
+      /* fall through with slug as title */
+    }
+  }
+
+  return {
+    id: slug,
+    title: `Blog: ${title}`,
+    column: TARGET_COLUMN,
+    labels: ['Blog'],
+    createdAt: commit.date,
+    updatedAt: commit.date,
+    history: [
+      { type: 'column', timestamp: commit.date, columnId: TARGET_COLUMN, columnTitle },
+    ],
+    description: description || `Published [${title}](/blog/${slug}).\n`,
+  };
+}
+
+function buildNewCard({ commit, conv, hasFlag, columnTitle }) {
+  const prNum = extractPrNumber(commit.subject);
+  const subjectForSlug = conv ? conv.message : commit.subject;
+  const cleaned = subjectForSlug.replace(/\s*\(#\d+\)\s*$/, '').trim();
+  const id = slugify(cleaned);
+  if (!id) return null;
+
+  const labels = [];
+  if (conv && TYPE_LABEL[conv.type]) labels.push(TYPE_LABEL[conv.type]);
+  if (conv?.breaking) labels.push('Breaking');
+  if (prNum) labels.push(`PR #${prNum}`);
+  if (hasFlag && !labels.length) labels.push('Tagged');
+
+  const description = commit.body
+    ? `${commit.body}\n`
+    : `${cleaned}\n`;
+
+  return {
+    id,
+    title: cleaned,
+    column: TARGET_COLUMN,
+    labels,
+    createdAt: commit.date,
+    updatedAt: commit.date,
+    history: [
+      { type: 'column', timestamp: commit.date, columnId: TARGET_COLUMN, columnTitle },
+    ],
+    description,
+  };
+}
+
+function moveCardToChangelog(card, commit, columnTitle) {
+  card.column = TARGET_COLUMN;
+  card.updatedAt = commit.date;
+  card.history = card.history || [];
+  card.history.push({
+    type: 'column',
+    timestamp: commit.date,
+    columnId: TARGET_COLUMN,
+    columnTitle,
+  });
+  return card;
+}
+
+async function main() {
+  const opts = parseArgs();
+  const boardId = opts.board;
+
+  const meta = await loadBoardMeta(boardId);
+  const targetColumn = meta.columns.find((c) => c.id === TARGET_COLUMN);
+  if (!targetColumn) {
+    throw new Error(`Board "${boardId}" has no column with id "${TARGET_COLUMN}"`);
+  }
+
+  const shas = resolveCommitRange(opts);
+  if (shas.length === 0) {
+    console.log('No commits to process.');
+    return;
+  }
+
+  const cards = await loadCards(boardId);
+  const cardsById = new Map(cards.map((c) => [c.id, c]));
+
+  const actions = [];
+  for (const sha of shas) {
+    const commit = getCommitInfo(sha);
+
+    // Blog posts: any commit that adds a content/blog/*.txt file gets a card
+    // per added post, regardless of commit type or skip rules.
+    const addedPosts = getAddedBlogPosts(sha);
+    if (addedPosts.length > 0) {
+      for (const slug of addedPosts) {
+        if (cardsById.has(slug)) {
+          actions.push({ sha, subject: commit.subject, action: 'noop', reason: 'blog card exists', card: slug });
+          continue;
+        }
+        const card = await buildBlogPostCard(slug, commit, targetColumn.title);
+        cardsById.set(card.id, card);
+        actions.push({ sha, subject: commit.subject, action: 'create', card: card.id, via: 'blog post' });
+      }
+      continue;
+    }
+
+    const cls = classifyCommit(commit);
+
+    if (cls.action === 'skip') {
+      actions.push({ sha, subject: commit.subject, action: 'skip', reason: cls.reason });
+      continue;
+    }
+
+    const match = findMatchingCard([...cardsById.values()], commit, cls.conv);
+    if (match) {
+      if (match.card.column === TARGET_COLUMN) {
+        actions.push({ sha, subject: commit.subject, action: 'noop', reason: 'already in changelog', via: match.via });
+        continue;
+      }
+      moveCardToChangelog(match.card, commit, targetColumn.title);
+      actions.push({ sha, subject: commit.subject, action: 'move', card: match.card.id, via: match.via });
+      continue;
+    }
+
+    if (cls.action === 'try-match-only') {
+      actions.push({ sha, subject: commit.subject, action: 'skip', reason: 'no match, type filtered' });
+      continue;
+    }
+
+    const newCard = buildNewCard({ commit, conv: cls.conv, hasFlag: cls.hasFlag, columnTitle: targetColumn.title });
+    if (!newCard) {
+      actions.push({ sha, subject: commit.subject, action: 'skip', reason: 'cannot derive id' });
+      continue;
+    }
+    if (cardsById.has(newCard.id)) {
+      // Defensive: a card with the same id already exists but earlier match missed it.
+      // Treat it like a move.
+      const existing = cardsById.get(newCard.id);
+      if (existing.column !== TARGET_COLUMN) {
+        moveCardToChangelog(existing, commit, targetColumn.title);
+        actions.push({ sha, subject: commit.subject, action: 'move', card: existing.id, via: 'late-id collision' });
+      } else {
+        actions.push({ sha, subject: commit.subject, action: 'noop', reason: 'id collision in changelog', card: existing.id });
+      }
+      continue;
+    }
+    cardsById.set(newCard.id, newCard);
+    actions.push({ sha, subject: commit.subject, action: 'create', card: newCard.id });
+  }
+
+  console.log(`\nProcessed ${shas.length} commit(s):\n`);
+  const counts = { skip: 0, noop: 0, move: 0, create: 0 };
+  for (const a of actions) {
+    counts[a.action] = (counts[a.action] || 0) + 1;
+    const tag = a.action.padEnd(7);
+    const reason = a.reason ? ` [${a.reason}]` : '';
+    const via = a.via ? ` (via ${a.via})` : '';
+    const cardRef = a.card ? ` → ${a.card}` : '';
+    console.log(`  ${tag} ${a.sha.slice(0, 7)}  ${a.subject}${cardRef}${via}${reason}`);
+  }
+  console.log(`\nSummary: ${counts.move} move, ${counts.create} create, ${counts.noop} noop, ${counts.skip} skip\n`);
+
+  if (opts.dryRun) {
+    console.log('Dry run — no files written.');
+    return;
+  }
+
+  // Write only cards that were actually changed.
+  const written = new Set();
+  for (const a of actions) {
+    if (a.action !== 'move' && a.action !== 'create') continue;
+    const card = cardsById.get(a.card);
+    if (!card) continue;
+    if (written.has(card.id)) continue;
+    const file = await saveCardMarkdown(boardId, card);
+    written.add(card.id);
+    console.log(`✓ Wrote ${file}`);
+  }
+
+  if (written.size > 0) {
+    // Bump board updatedAt so precompiled output picks up changes.
+    const boardPath = join(CONTENT_DIR, boardId, '_board.md');
+    const boardContent = await readFile(boardPath, 'utf-8');
+    const { content: body, data: bm } = matter(boardContent);
+    bm.updatedAt = new Date().toISOString();
+    await writeFile(boardPath, matter.stringify(body, bm));
+    console.log(`✓ Bumped ${boardPath}`);
+  } else {
+    console.log('No card files needed updating.');
+  }
+}
+
+main().catch((err) => {
+  console.error(`\n❌ ${err.stack || err.message}`);
+  process.exit(1);
+});

--- a/src/generated/kanban/manifest.js
+++ b/src/generated/kanban/manifest.js
@@ -13,6 +13,6 @@ export const kanbanManifest = {
   "roadmap": {
     "file": "roadmap.js",
     "title": "Site Roadmap",
-    "cardCount": 59
+    "cardCount": 79
   }
 };

--- a/src/generated/kanban/roadmap.js
+++ b/src/generated/kanban/roadmap.js
@@ -275,6 +275,284 @@ export const board = {
       "title": "Change Log",
       "cards": [
         {
+          "id": "refactor-search-console-fetch-and-add-summary-only",
+          "title": "refactor Search Console fetch and add summary-only mode",
+          "labels": [
+            "Feature"
+          ],
+          "checklist": [],
+          "createdAt": "2026-04-26T01:46:01.000Z",
+          "updatedAt": "2026-04-26T01:46:01.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-04-26T01:46:01.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "- Split Search Console query into two calls: an authoritative\n  no-dimension summary and a dimensional rows fetch. Previously the\n  summary was derived by summing rows, which under-counted clicks/\n  impressions because the row response is capped and aggregated by\n  (query, page) — a single page can split across many rows.\n- Replace ad-hoc reductions with summarizeRows / aggregateRows /\n  weightedAveragePosition helpers; impression-weighted positions\n  replace simple averages.\n- Make the daily history write idempotent (update existing date entry\n  instead of appending a duplicate).\n- Add --update-summary-only mode that re-reads the latest history\n  entry and rewrites docs/metrics/latest.json, preserving the original\n  timestamp. The daily workflow now invokes this after fetch-ga4-data.js\n  so the GA4 step's latest.json overwrite doesn't drop fresh Search\n  Console numbers.\n- updateMetricsSummary now takes a lastCheck override so the summary-\n  only path doesn't bump the timestamp to \"now\".\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+        },
+        {
+          "id": "make-blog-the-first-and-default-tab",
+          "title": "make Blog the first and default tab",
+          "labels": [
+            "Feature"
+          ],
+          "checklist": [],
+          "createdAt": "2026-04-26T01:39:01.000Z",
+          "updatedAt": "2026-04-26T01:39:01.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-04-26T01:39:01.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "Reorders ANALYTICS_TABS so Blog is first and sets it as the initial\nactiveTab. Also fixes the Search CTR display (averageCTR is already a\npercentage; the extra *100 was double-scaling it).\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+        },
+        {
+          "id": "add-preinstall-guard-section",
+          "title": "add preinstall guard section",
+          "labels": [],
+          "checklist": [],
+          "createdAt": "2026-03-31T13:31:10.000Z",
+          "updatedAt": "2026-03-31T13:31:10.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-31T13:31:10.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "Documents the npm install blocker that forces npm ci usage,\nclosing the gap between having a lockfile and actually using it.\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+        },
+        {
+          "id": "fix-quarantine-section-min-release-age-not-enforce",
+          "title": "fix quarantine section — min-release-age not enforced in npm 11",
+          "labels": [],
+          "checklist": [],
+          "createdAt": "2026-03-31T13:26:04.000Z",
+          "updatedAt": "2026-03-31T13:26:04.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-31T13:26:04.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "npm warns \"Unknown user config\" for min-release-age, so it's not\nactually protecting anything. Kept uv exclude-newer (which works)\nand noted npm doesn't have an equivalent yet.\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+        },
+        {
+          "id": "add-7-day-quarantine-hardening-section",
+          "title": "add 7-day quarantine hardening section",
+          "labels": [],
+          "checklist": [],
+          "createdAt": "2026-03-31T13:23:16.000Z",
+          "updatedAt": "2026-03-31T13:23:16.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-31T13:23:16.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "Added min-release-age=7 (npm) and exclude-newer (uv) as a third\nhardening measure alongside save-exact and version pinning.\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+        },
+        {
+          "id": "consolidate-tags-remove-8-singletons",
+          "title": "consolidate tags — remove 8 singletons",
+          "labels": [],
+          "checklist": [],
+          "createdAt": "2026-03-31T11:28:33.000Z",
+          "updatedAt": "2026-03-31T11:28:33.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-31T11:28:33.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "Merged low-use tags into existing ones:\n- Observability, Automation → SRE\n- CMS, SEO, Node.js → Web Dev (or removed)\n- Spotify → Projects (removed)\n- Supply Chain → Security (removed)\n\n21 tags → 13.\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+        },
+        {
+          "id": "2026-03-31-axios-supply-chain-attack",
+          "title": "Blog: Anatomy of the axios Supply Chain Attack (and How We Checked Our Machines in 10 Minutes)",
+          "labels": [
+            "Blog"
+          ],
+          "checklist": [],
+          "createdAt": "2026-03-31T11:14:35.000Z",
+          "updatedAt": "2026-03-31T11:14:35.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-31T11:14:35.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "A compromised npm maintainer account pushed malware into axios. Here's how the attack worked, what it installed, and how we checked our machines in 10 minutes."
+        },
+        {
+          "id": "eliminate-ai-slop-patterns-across-24-posts",
+          "title": "eliminate AI slop patterns across 24 posts",
+          "labels": [
+            "PR #272"
+          ],
+          "checklist": [],
+          "createdAt": "2026-03-28T18:25:48.000Z",
+          "updatedAt": "2026-03-28T18:25:48.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-28T18:25:48.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "* blog: eliminate AI slop patterns across 24 posts\n\nRun slop-guard (https://github.com/eric-tramel/slop-guard) across all\nblog posts and rewrite flagged patterns. All 30 posts now score >= 81/100\n(up from a low of 8/100).\n\nChanges across all posts:\n- Replaced slop words (reflecting, narrative, leverage, significantly,\n  surprisingly, navigate, collaborative, comprehensive, notable)\n- Rewrote \"X, not Y\" contrast pairs as direct claims\n- Removed \"This is not X. It is Y\" setup-resolution patterns\n- Expanded or cut pithy one-liner fragments\n- Converted bold-bullet listicle blocks to prose paragraphs\n- Reduced excessive bullet runs and triadic list cadences\n- Varied repeated phrases\n- Cut slop phrases (\"the key insight\", \"deliberate choice\", \"feel free to\")\n\nAll frontmatter, code blocks, React components, internal links, and\nASCII diagrams preserved unchanged.\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>\n\n* blog: fix writing quality violations from proposed slop-guard rules\n\nAddress violations from proposed writing quality rules (eric-tramel/slop-guard#9):\n- \"tip of the iceberg\" cliche → \"symptoms of deeper structural issues\"\n- \"deep dive\" cliche → \"full technical breakdown\"\n- \"best practices\" cliche → \"web standards\"\n- \"very\" qualifier → cut\n- \"wonderful\" ecstatic adjective → \"disarming\"\n- \"naturally tried to optimize\" (over-explanation + pretentious) → \"tried to shrink\"\n\nIntentionally kept:\n- \"obviously\" in echonest-sync (intentional humor about airhorns)\n- \"## The Journey\" headings (inside code blocks, referencing template name)\n- \"subsequent\" in theme-persistence (technical term: \"subsequent navigation\")\n- \"rather\" in \"rather than\" comparisons (conjunction, not hedging qualifier)\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>\n\n---------\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+        },
+        {
+          "id": "inline-diff-in-codex-review-prompt-to-avoid-sandbo",
+          "title": "inline diff in codex review prompt to avoid sandbox errors",
+          "labels": [
+            "Bugfix",
+            "PR #271"
+          ],
+          "checklist": [],
+          "createdAt": "2026-03-28T16:26:04.000Z",
+          "updatedAt": "2026-03-28T16:26:04.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-28T16:26:04.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "The Codex CLI read-only sandbox (bwrap) blocks file reads with\n\"RTM_NEWADDR: Operation not permitted\". Fix by passing the diff\ndirectly in the prompt instead of writing to pr_diff.txt and\nasking Codex to read it.\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+        },
+        {
+          "id": "add-60-day-rolling-window-and-remove-redundant-leg",
+          "title": "add 60-day rolling window and remove redundant legend",
+          "labels": [
+            "Bugfix",
+            "PR #270"
+          ],
+          "checklist": [],
+          "createdAt": "2026-03-28T16:19:25.000Z",
+          "updatedAt": "2026-03-28T16:19:25.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-28T16:19:25.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "* fix(analytics): add 60-day rolling window and remove redundant legend\n\n- Filter Sessions Over Time, Search Performance, and Blog Traffic charts\n  to show only the last 60 days instead of all historical data\n- Remove redundant legend from Device Breakdown donut chart (labels\n  already display device name and percentage)\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>\n\n* fix: bundle mermaid+dagre together and add missing react-is dep\n\n- Add manualChunks rule to bundle mermaid and dagre into a single chunk,\n  preventing stale hash errors when cached mermaid chunks reference\n  old dagre chunk filenames after redeployment\n- Add react-is as a direct dependency (required by recharts at build\n  time but only present as a transitive dev dependency)\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>\n\n---------\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+        },
+        {
+          "id": "deduplicate-anomaly-alerts-for-sustained-trends",
+          "title": "deduplicate anomaly alerts for sustained trends",
+          "labels": [
+            "Bugfix"
+          ],
+          "checklist": [],
+          "createdAt": "2026-03-28T15:57:22.000Z",
+          "updatedAt": "2026-03-28T15:57:22.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-28T15:57:22.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "Instead of creating a new issue every day during a prolonged traffic\ndecline, append updates as comments on the most recent open anomaly\nissue (within 3 days). New issues are still created for fresh incidents.\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+        },
+        {
+          "id": "tweak-wording-in-watchdogs-post",
+          "title": "tweak wording in watchdogs post",
+          "labels": [],
+          "checklist": [],
+          "createdAt": "2026-03-14T15:15:46.000Z",
+          "updatedAt": "2026-03-14T15:15:46.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-14T15:15:46.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+        },
+        {
+          "id": "2026-03-14-watchdogs-and-launchagents",
+          "title": "Blog: Watchdogs and LaunchAgents: Managing Systems That Want to Break",
+          "labels": [
+            "Blog"
+          ],
+          "checklist": [],
+          "createdAt": "2026-03-14T14:57:07.000Z",
+          "updatedAt": "2026-03-14T14:57:07.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-14T14:57:07.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "What we learned building a watchdog for BlueBubbles and OpenClaw on a headless Mac Mini. Health monitors that cause the instability they're designed to detect, and how to fix them."
+        },
+        {
+          "id": "use-7-day-rolling-average-for-analytics-anomaly-de",
+          "title": "use 7-day rolling average for analytics anomaly detection",
+          "labels": [
+            "Bugfix",
+            "PR #258"
+          ],
+          "checklist": [],
+          "createdAt": "2026-03-07T00:50:55.000Z",
+          "updatedAt": "2026-03-07T00:50:55.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-03-07T00:50:55.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "The previous day-over-day comparison triggered false positives when traffic\nreturned to baseline after a spike (e.g. 573→318 = -45%, but 318 is normal).\n\nNow compares against the 7-day rolling average with a -40% threshold, which\nis more resilient to natural traffic fluctuations.\n\nCloses #256\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>"
+        },
+        {
+          "id": "2026-02-26-echonest-sync-and-the-spotify-api-shakeup",
+          "title": "Blog: EchoNest Sync and the Spotify API Shakeup",
+          "labels": [
+            "Blog"
+          ],
+          "checklist": [],
+          "createdAt": "2026-02-27T00:26:38.000Z",
+          "updatedAt": "2026-02-27T00:26:38.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-02-27T00:26:38.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "We built a desktop sync app for EchoNest. Then Spotify changed its API in ways that made us glad we did."
+        },
+        {
           "id": "streamline-blog-post-build-deploy-pipeline",
           "title": "Streamline blog post build/deploy pipeline",
           "labels": [
@@ -298,6 +576,103 @@ export const board = {
             }
           ],
           "description": "Added a `detect-changes` job to `deploy.yml` that classifies pushes as content-only or full-build. Content-only deploys skip Playwright tests, unit tests, Sentry source maps, security audit, and bundle size checks. Deployed in PR #249. Full pipeline: ~10min → Content-only: ~2min."
+        },
+        {
+          "id": "harden-openclaw-post-security-posture",
+          "title": "harden OpenClaw post security posture",
+          "labels": [
+            "PR #248"
+          ],
+          "checklist": [],
+          "createdAt": "2026-02-24T22:56:10.000Z",
+          "updatedAt": "2026-02-24T22:56:10.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-02-24T22:56:10.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "* blog: harden OpenClaw post security posture\n\n- Remove specific locations, chat counts, plist names, exact schedules\n- Generalize infrastructure to \"Mac-class device\" / \"system service\"\n- Describe guardrails as principles (least privilege, separate service\n  accounts, out-of-band approval) rather than exact mechanisms\n- Reframe hard parts as lessons learned, not precise failure modes\n- Remove personal schedule details; add consent language for shared data\n- Add monitoring/detection section (weekly activity report, anomaly alerts)\n- Remove GOG_KEYRING_PASSWORD and other implementation specifics\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\n\n* blog: humanizer pass on OpenClaw post\n\n- Remove formulaic openers (\"The lesson:\", \"The takeaway:\", \"The goal\")\n- Break up rule-of-three/five feature lists into shorter sentences\n- Rewrite security paragraph from brochure tone to plain language\n- Cut negative parallelism (\"not just X, but Y\")\n- Vary sentence structure and rhythm throughout\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\n\n---------\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>"
+        },
+        {
+          "id": "improve-openclaw-post-intro-and-link",
+          "title": "improve OpenClaw post intro and link",
+          "labels": [
+            "PR #247"
+          ],
+          "checklist": [],
+          "createdAt": "2026-02-24T21:39:52.000Z",
+          "updatedAt": "2026-02-24T21:39:52.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-02-24T21:39:52.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "* blog: improve OpenClaw post intro with context and link\n\n- Link OpenClaw to https://openclaw.ai/\n- Frame as exploration of an open-source AI agent framework\n- Add context on what OpenClaw is and why it's notable\n- Fix location: Mac Mini is in the cabin, not apartment\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\n\n* blog: reframe OpenClaw post and run humanizer pass\n\n- Reframe as experimentation with safety-first approach\n- Remove camera snapshot section\n- Link OpenClaw to https://openclaw.ai/\n- Fix Mac Mini location (cabin not apartment)\n- Humanizer pass: remove bolded inline headers, reduce AI\n  vocabulary, vary sentence structure, cut promotional tone\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\n\n---------\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>"
+        },
+        {
+          "id": "rework-blog-analytics-dashboard",
+          "title": "rework blog analytics dashboard",
+          "labels": [
+            "Feature",
+            "PR #246"
+          ],
+          "checklist": [],
+          "createdAt": "2026-02-24T21:33:28.000Z",
+          "updatedAt": "2026-02-24T21:33:28.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-02-24T21:33:28.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "* feat(analytics): rework blog analytics dashboard\n\n- Add all-time leaderboard aggregating GA4 history across all entries\n- Fix slug matching for renamed posts via alias map + year normalization\n- Replace single-line blog traffic chart with stacked area (top 5 posts)\n- Replace avg reading time metric with all-time views; add WoW trend\n- Switch tag breakdown to all-time data; remove sparse category pie chart\n- Trim 7d table to top 5, streamline columns\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\n\n* fix(analytics): address Codex review feedback\n\n- Remove risky partial substring matching in slug resolver to prevent\n  silent data misattribution; add min key length guard (>=10 chars)\n- Use Date.getTime() for firstSeen/lastSeen comparisons instead of\n  string comparison to handle non-ISO date formats safely\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\n\n---------\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>"
+        },
+        {
+          "id": "make-security-audit-non-blocking-in-deploy-workflo",
+          "title": "make security audit non-blocking in deploy workflow",
+          "labels": [
+            "Bugfix",
+            "PR #245"
+          ],
+          "checklist": [],
+          "createdAt": "2026-02-24T21:24:15.000Z",
+          "updatedAt": "2026-02-24T21:24:15.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-02-24T21:24:15.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "The deploy workflow's npm audit step was failing the entire build due to\ntransitive dependency vulnerabilities in dev tools (eslint, minimatch, glob).\nThese are not exploitable in production.\n\nAligns with pr-checks.yml which already has continue-on-error: true and\n--omit=dev for the audit step.\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>"
+        },
+        {
+          "id": "2026-02-24-openclaw-the-home-agent",
+          "title": "Blog: OpenClaw: Experimenting with a personal AI agent",
+          "labels": [
+            "Blog"
+          ],
+          "checklist": [],
+          "createdAt": "2026-02-24T20:53:10.000Z",
+          "updatedAt": "2026-02-24T20:53:10.000Z",
+          "history": [
+            {
+              "type": "column",
+              "timestamp": "2026-02-24T20:53:10.000Z",
+              "columnId": "changelog",
+              "columnTitle": "Change Log"
+            }
+          ],
+          "description": "What I learned running an open-source AI agent on a self-hosted Mac Mini. Least privilege, version-controlled config, and the boring plumbing that makes it work."
         },
         {
           "id": "rework-tablist-mobile-selector",
@@ -2554,5 +2929,5 @@ export const board = {
     }
   ],
   "createdAt": "2026-01-16T14:45:27.429Z",
-  "updatedAt": "2026-01-23T15:59:45.003Z"
+  "updatedAt": "2026-04-26T02:20:54.616Z"
 };


### PR DESCRIPTION
## Summary

The roadmap board's changelog column had been stale for ~2 months — last entry on 2026-02-24, despite ~20 changelog-worthy commits landing during that window. This PR adds automation to keep it current going forward, and backfills the gap.

- **Automation:** `scripts/sync-changelog.js` + `.github/workflows/sync-changelog.yml`. On every push to main, walks the new commits and either moves a matching existing card to `changelog` (by `PR #N` label or slug match) or creates a new card from `feat:`/`fix:`/`perf:`/`[changelog]`-tagged commits and from new `content/blog/*.txt` files. Skips dependabot, daily analytics, and `chore`/`deps`/`docs`/`ci`/`build`/`style`/`test`/`refactor` without `[changelog]`.
- **Backfill (third commit):** 20 cards covering 4 blog posts (OpenClaw, EchoNest Sync, watchdogs, axios), 6 feat/fix/perf commits, and 10 blog edits. Changelog goes from 54 → 74 cards.
- **Side-fix (first commit):** `scripts/precompile-kanban.js` was crashing on Zod-v4 validation errors because the formatter still referenced `.error.errors` (renamed to `.issues` in v4).

## Behavior details

- The bot commit doesn't carry `[skip ci]` so deploy.yml's content-only fast path runs (~2min) and the new card lands on the live site.
- `paths-ignore` on `content/kanban/**` and `src/generated/kanban/**` prevents the workflow from self-triggering on its own commit.
- Renames are followed: a renamed blog post resolves to its current slug, not the original.
- `workflow_dispatch` exposes `since` SHA + `dry_run` inputs for ad-hoc backfills.
- New flags documented in CLAUDE.md: `[skip-changelog]` (opt out) and `[changelog]` (force include).

## Test plan

- [ ] Verify the 74 cards render in the Change Log Explorer at `/projects/changelog`.
- [ ] After merge, push a `feat:` or `fix:` commit and confirm the workflow creates a card.
- [ ] After merge, push a new blog post and confirm a Blog: card lands.
- [ ] Push a `chore:` commit and confirm no card is created.
- [ ] Run `Actions → Sync Changelog → Run workflow` with `dry_run=true` to validate output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)