### PR TITLE
chore(deps): add 7-day cooldown to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    # Supply-chain safety: refuse versions newer than N days, so any
+    # malicious upload (typosquats, hijacked maintainers) has time to
+    # be caught and yanked before Dependabot proposes it. Mirrors the
+    # `exclude-newer = "7 days"` setting on uv globally.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     # SRE Safety: Block major version updates for critical dependencies
     ignore:
       - dependency-name: "react"
@@ -61,6 +70,8 @@ updates:
       - "Dbochman"
     commit-message:
       prefix: "ci"
+    cooldown:
+      default-days: 7
     # Group GitHub Actions updates
     groups:
       github-actions:


### PR DESCRIPTION
## Summary
- Adds `cooldown:` config to both `updates:` blocks in `.github/dependabot.yml`.
- Dependabot will refuse to propose package versions published within the cooldown window, so malicious uploads (typosquats, hijacked maintainers) get a chance to be caught and yanked before they reach our build.
- Mirrors the `exclude-newer = "7 days"` setting already configured globally for uv on both my local and the mac mini.

## Windows
| Ecosystem | Default | Major | Minor | Patch |
|-----------|---------|-------|-------|-------|
| npm | 7d | 14d | 7d | 3d |
| github-actions | 7d | — | — | — |

Patch is shorter because patches are usually security fixes — the cost of waiting is higher. Major is longer because the blast radius of a compromised major is bigger.

## Test plan
- [ ] Dependabot reads new config without warnings (visible in repo Insights → Dependency graph → Dependabot logs after first scheduled run)
- [ ] Existing open Dependabot PRs (#285, #286, #287) are unaffected — cooldown only applies to *new* proposals
- [ ] Next Monday's Dependabot run respects the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)