### PR TITLE
fix(deps): migrate to lucide-react 1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "framer-motion": "^12.38.0",
         "googleapis": "^171.4.0",
         "gray-matter": "^4.0.3",
-        "lucide-react": "^0.563.0",
+        "lucide-react": "^1.8.0",
         "mermaid": "^11.12.2",
         "next-themes": "^0.4.6",
         "react": "^18.3.1",
@@ -9584,9 +9584,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.563.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
-      "integrity": "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "framer-motion": "^12.38.0",
     "googleapis": "^171.4.0",
     "gray-matter": "^4.0.3",
-    "lucide-react": "^0.563.0",
+    "lucide-react": "^1.8.0",
     "mermaid": "^11.12.2",
     "next-themes": "^0.4.6",
     "react": "^18.3.1",

--- a/src/components/analytics/MetricCard.tsx
+++ b/src/components/analytics/MetricCard.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
-import { LucideIcon, TrendingUp, TrendingDown } from 'lucide-react';
+import { TrendingUp, TrendingDown, type LucideIcon } from 'lucide-react';
 
 interface MetricCardProps {
   title: string;

--- a/src/components/icons/LinkedinIcon.tsx
+++ b/src/components/icons/LinkedinIcon.tsx
@@ -1,0 +1,17 @@
+export function LinkedinIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M21,21H17V14.25C17,13.19 15.81,12.31 14.75,12.31C13.69,12.31 13,13.19 13,14.25V21H9V9H13V11C13.66,9.93 15.36,9.24 16.5,9.24C19,9.24 21,11.28 21,13.75V21M7,21H3V9H7V21M5,3A2,2 0 0,1 7,5A2,2 0 0,1 5,7A2,2 0 0,1 5,3Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -1,7 +1,8 @@
 
 import React from 'react';
 import { Button } from "@/components/ui/button";
-import { Mail, Linkedin } from "lucide-react";
+import { Mail } from "lucide-react";
+import { LinkedinIcon } from "@/components/icons/LinkedinIcon";
 import SloGauge from "@/components/icons/SloGauge";
 import UptimeTimeline from "@/components/icons/UptimeTimeline";
 import { Footer } from "@/components/layout/Footer";
@@ -50,7 +51,7 @@ const ContactSection = () => {
                 });
               }
             }}>
-              <Linkedin className="w-4 h-4 mr-2" />
+              <LinkedinIcon className="w-4 h-4 mr-2" />
               LinkedIn
             </a>
           </Button>

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 import { Button } from "@/components/ui/button";
-import { Mail, Linkedin, MapPin, Activity } from "lucide-react";
+import { Mail, MapPin, Activity } from "lucide-react";
 import { GitHubMark } from "@/components/icons/GitHubMark";
+import { LinkedinIcon } from "@/components/icons/LinkedinIcon";
 import ErrorRateChart from "@/components/icons/ErrorRateChart";
 import LatencyHistogram from "@/components/icons/LatencyHistogram";
 import AlertCounter from "@/components/icons/AlertCounter";
@@ -63,7 +64,7 @@ const HeroSection = () => {
             </Button>
             <Button size="lg" className="bg-foreground text-background hover:bg-foreground/90 hover-lift font-medium" asChild>
               <a href="https://www.linkedin.com/in/dbochman/" target="_blank" rel="noopener noreferrer" aria-label="Visit Dylan Bochman's LinkedIn profile">
-                <Linkedin className="w-4 h-4 mr-2" />
+                <LinkedinIcon className="w-4 h-4 mr-2" />
                 LinkedIn
               </a>
             </Button>


### PR DESCRIPTION
## Summary
Lucide 1.x has two breaking changes that hit our codebase:

1. **`LucideIcon` is type-only.** It used to be a value export, now it isn't. One file (`MetricCard.tsx`) imported it as a value — switched to `type LucideIcon`.
2. **`Linkedin` icon was removed.** Brand icons got dropped in 1.x. We use it in two places (HeroSection, ContactSection). Replaced with a small `LinkedinIcon` component using inline SVG, matching the existing `GitHubMark` pattern. No new dependency.

This supersedes the failing dependabot PR #292.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — all 215 tests pass against lucide-react 1.8.0
- [ ] Visual check on /  (HeroSection LinkedIn button) and /#contact (ContactSection LinkedIn button) after merge

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)