### PR TITLE
fix(seo): prerender root route to eliminate Soft 404 reports

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -55,6 +55,7 @@ async function prerender() {
     ];
 
     const routes = [
+      '/',
       '/projects',
       ...projectSlugs.map(slug => `/projects/${slug}`),
       '/runbook',


### PR DESCRIPTION
## Summary
- Adds `/` to the prerender routes in `scripts/prerender.mjs`
- `dist/index.html` now ships as the fully rendered homepage (~120KB) instead of the empty 10KB SPA shell

## Why
Google Search Console flagged these URLs as Soft 404:
- `http://dylanbochman.com/index.html`
- `http://www.dylanbochman.com/index.html`

All other routes (`/blog`, `/projects`, etc.) are prerendered, but `/` was never in the routes array — so when Googlebot fetched `/index.html` without executing JS, it saw `<div id="root"></div>` and an otherwise empty body. That's the classic Soft 404 trigger.

Both `/` and `/index.html` resolve to the same file on GitHub Pages, so this single change fixes both reported URLs.

## Test plan
- [x] `npm run build` succeeds; prerender log shows `➜ /` followed by `✓ Generated dist/index.html`
- [x] `dist/index.html` is ~120KB and contains rendered React content inside `<div id="root">`
- [ ] After merge + deploy, click "Validate Fix" in GSC for the Soft 404 item

🤖 Generated with [Claude Code](https://claude.com/claude-code)