### PR TITLE
[codex] fix search indexing routes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -222,6 +222,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
+      - name: Checkout source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
+
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -238,3 +246,14 @@ jobs:
           git add .
           git commit -m "Deploy $(date -u +%Y-%m-%dT%H:%M:%SZ)"
           git push --force "https://x-access-token:${{ secrets.DEPLOY_TOKEN }}@github.com/Dbochman/dbochman.github.io.git" main
+
+      - name: Verify live route artifacts
+        # Verifies actual GitHub Pages serving behavior — specifically that
+        # /foo is served from foo.html (not 3xx-redirected to /foo/) when
+        # both foo.html and foo/index.html exist. Static dist checks alone
+        # can't catch a host-level precedence regression. The script only
+        # uses Node stdlib, so no npm install is needed.
+        run: |
+          echo "Waiting for GitHub Pages to propagate..."
+          sleep 45
+          node scripts/smoke-live-routes.mjs https://dylanbochman.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,9 @@ jobs:
         env:
           GITHUB_SHA: ${{ github.sha }}
 
+      - name: Verify SEO route artifacts
+        run: npm run verify-seo-routes
+
       - name: Upload source maps to Sentry
         if: needs.detect-changes.outputs.is_content_only != 'true'
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -222,14 +222,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - name: Checkout source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: '24'
-
+      # No source checkout in this job — the deploy push must contain ONLY
+      # the build artifact, never source files. The verify-live job (below)
+      # owns source access for the smoke check.
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -247,13 +242,29 @@ jobs:
           git commit -m "Deploy $(date -u +%Y-%m-%dT%H:%M:%SZ)"
           git push --force "https://x-access-token:${{ secrets.DEPLOY_TOKEN }}@github.com/Dbochman/dbochman.github.io.git" main
 
+  verify-live:
+    # Probes the live deployment to confirm GitHub Pages actually serves
+    # /foo from foo.html (not a 3xx to /foo/) when both foo.html and
+    # foo/index.html exist, and that trailing-slash / legacy URLs serve
+    # the right meta-refresh redirect. Runs in its own job with a fresh
+    # workspace so source files are physically separated from the deploy
+    # push that already completed.
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: ./dist
+
       - name: Verify live route artifacts
-        # Verifies actual GitHub Pages serving behavior — specifically that
-        # /foo is served from foo.html (not 3xx-redirected to /foo/) when
-        # both foo.html and foo/index.html exist. Static dist checks alone
-        # can't catch a host-level precedence regression. The script only
-        # uses Node stdlib, so no npm install is needed.
-        run: |
-          echo "Waiting for GitHub Pages to propagate..."
-          sleep 45
-          node scripts/smoke-live-routes.mjs https://dylanbochman.com
+        run: node scripts/smoke-live-routes.mjs https://dylanbochman.com ./dist ./src/data/seo-redirects.json

--- a/index.html
+++ b/index.html
@@ -41,12 +41,10 @@
       })();
     </script>
     <title>Dylan Bochman - Site Reliability Engineer & Incident Manager</title>
-    <link rel="canonical" href="https://dylanbochman.com" />
     <link rel="icon" id="favicon" href="/favicon-light.ico" />
     <link rel="icon" id="favicon-16" type="image/png" sizes="16x16" href="/favicon-16x16-light.png" />
     <link rel="icon" id="favicon-32" type="image/png" sizes="32x32" href="/favicon-32x32-light.png" />
     <link rel="apple-touch-icon" id="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-light.png" />
-    <meta property="og:url" content="https://dylanbochman.com" />
     <meta name="description" content="Site Reliability Engineer (SRE) and Technical Incident Manager specializing in reliability, incident management, and SLO monitoring. Experience at Groq, HashiCorp, and Spotify." />
     <meta name="keywords" content="Site Reliability Engineering, SRE, Technical Incident Manager, Incident Management, Groq, HashiCorp, Spotify, Post-Incident Analysis, SLO Monitoring, Operational Readiness, Infrastructure Reliability, DevOps, System Reliability, Incident Response, Dylan Bochman" />
     <meta name="author" content="Dylan Bochman" />

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "preview": "vite preview",
     "prerender": "node scripts/prerender.mjs",
     "verify-seo-routes": "node scripts/verify-seo-routes.mjs",
+    "smoke-live-routes": "node scripts/smoke-live-routes.mjs",
     "test": "vitest",
     "test:watch": "vitest",
     "test:coverage": "vitest --coverage",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "prerender": "node scripts/prerender.mjs",
+    "verify-seo-routes": "node scripts/verify-seo-routes.mjs",
     "test": "vitest",
     "test:watch": "vitest",
     "test:coverage": "vitest --coverage",

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -13,7 +13,7 @@
       <link>https://dylanbochman.com/blog</link>
     </image>
     <item>
-      <title>Two Supply Chain Attacks in One Day (and a Setting I Used to Argue Against)</title>
+      <title>Two Supply Chain Attacks in One Day</title>
       <link>https://dylanbochman.com/blog/2026-04-30-two-supply-chain-attacks-in-one-day</link>
       <guid isPermaLink="true">https://dylanbochman.com/blog/2026-04-30-two-supply-chain-attacks-in-one-day</guid>
       <description>Lightning on PyPI and intercom-client on npm got compromised the same morning by what looks like the same attacker. We weren&apos;t exposed, but the threat shape changed enough that I walked back a position I took a month ago.</description>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,85 +2,79 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://dylanbochman.com/</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/blog</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/runbook</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/slo-tool</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/statuspage-update</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/oncall-coverage</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/kanban</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/analytics</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/changelog</loc>
-    <lastmod>2026-05-08</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://dylanbochman.com/projects/cli-playground</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/incident-command-diagrams</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/k8s-rightsizer</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/echonest</loc>
-    <lastmod>2026-05-08</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/generate-feeds.ts
+++ b/scripts/generate-feeds.ts
@@ -36,6 +36,7 @@ interface BlogPostForFeed {
 
 interface ProjectForSitemap {
   slug: string;
+  status?: string;
 }
 
 /**
@@ -81,7 +82,8 @@ function loadProjects(): ProjectForSitemap[] {
     process.exit(1);
   }
 
-  return JSON.parse(fs.readFileSync(projectsPath, 'utf8')) as ProjectForSitemap[];
+  return (JSON.parse(fs.readFileSync(projectsPath, 'utf8')) as ProjectForSitemap[])
+    .filter(project => project.status !== 'draft');
 }
 
 /**

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -12,13 +12,12 @@ const __dirname = dirname(__filename);
 const distDir = join(__dirname, '..', 'dist');
 const blogManifestPath = join(__dirname, '..', 'src', 'generated', 'blog', 'manifest.json');
 const projectsMetaPath = join(__dirname, '..', 'src', 'data', 'projects-meta.json');
+const seoRedirectsPath = join(__dirname, '..', 'src', 'data', 'seo-redirects.json');
 
 // Hardcoded legacy redirects that aren't derivable from the blog manifest.
-// Keep this list small; manifest-driven redirects are preferred.
-const LEGACY_REDIRECTS = [
-  { from: '/projects/andre', to: '/projects/echonest' },
-  { from: '/blog/2026-02-04-andre-collaborative-music-queue', to: '/blog/2026-02-04-echonest-collaborative-music-queue' },
-];
+// Single source of truth: src/data/seo-redirects.json (also read by
+// scripts/verify-seo-routes.mjs and scripts/smoke-live-routes.mjs).
+const { legacyRedirects: LEGACY_REDIRECTS } = JSON.parse(readFileSync(seoRedirectsPath, 'utf-8'));
 
 function routeToOutputPath(route) {
   if (route === '/') {

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { chromium } from '@playwright/test';
-import { readFileSync, readdirSync, writeFileSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { exec } from 'child_process';
@@ -10,8 +10,39 @@ const execAsync = promisify(exec);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const distDir = join(__dirname, '..', 'dist');
-const blogContentDir = join(__dirname, '..', 'content', 'blog');
+const blogManifestPath = join(__dirname, '..', 'src', 'generated', 'blog', 'manifest.json');
 const projectsMetaPath = join(__dirname, '..', 'src', 'data', 'projects-meta.json');
+
+function routeToOutputPath(route) {
+  if (route === '/') {
+    return join(distDir, 'index.html');
+  }
+
+  const cleanRoute = route.replace(/^\/+|\/+$/g, '');
+  if (route.endsWith('/')) {
+    return join(distDir, cleanRoute, 'index.html');
+  }
+
+  return join(distDir, `${cleanRoute}.html`);
+}
+
+function loadBlogRoutes() {
+  const manifest = JSON.parse(readFileSync(blogManifestPath, 'utf-8'));
+
+  return Object.entries(manifest)
+    .filter(([, entry]) => !entry.frontmatter.draft)
+    .map(([filenameSlug, entry]) => ({
+      route: `/blog/${entry.frontmatter.slug ?? filenameSlug}`,
+      legacyRoute: entry.frontmatter.slug && entry.frontmatter.slug !== filenameSlug
+        ? `/blog/${filenameSlug}`
+        : null,
+    }));
+}
+
+function loadPublicProjects() {
+  const projectsMeta = JSON.parse(readFileSync(projectsMetaPath, 'utf-8'));
+  return projectsMeta.filter(project => project.status !== 'draft');
+}
 
 /**
  * Pre-render routes to static HTML files for GitHub Pages
@@ -37,13 +68,9 @@ async function prerender() {
     const browser = await chromium.launch();
     const page = await browser.newPage();
 
-    // Get list of blog posts
-    const blogFiles = readdirSync(blogContentDir).filter(f => f.endsWith('.txt'));
-    const blogSlugs = blogFiles.map(f => f.replace('.txt', ''));
-
-    // Get list of projects
-    const projectsMeta = JSON.parse(readFileSync(projectsMetaPath, 'utf-8'));
-    const projectSlugs = projectsMeta.map(p => p.slug);
+    // Get indexable content from the same generated data used by the sitemap.
+    const blogRoutes = loadBlogRoutes();
+    const projectSlugs = loadPublicProjects().map(p => p.slug);
 
     // Old routes that redirect to new ones — must be prerendered so GitHub Pages
     // serves the SPA shell which performs the client-side redirect
@@ -52,6 +79,11 @@ async function prerender() {
       '/projects/andre/',
       '/blog/2026-02-04-andre-collaborative-music-queue',
       '/blog/2026-02-04-andre-collaborative-music-queue/',
+      ...blogRoutes
+        .flatMap(blogRoute => blogRoute.legacyRoute
+          ? [blogRoute.legacyRoute, `${blogRoute.legacyRoute}/`]
+          : []
+        )
     ];
 
     const routes = [
@@ -61,7 +93,7 @@ async function prerender() {
       '/runbook',
       '/analytics',
       '/blog',
-      ...blogSlugs.map(slug => `/blog/${slug}`),
+      ...blogRoutes.map(blogRoute => blogRoute.route),
       ...redirectRoutes,
     ];
 
@@ -85,10 +117,9 @@ async function prerender() {
       // Get the rendered HTML
       const html = await page.content();
 
-      // Determine output path
-      const outputPath = route === '/blog'
-        ? join(distDir, 'blog', 'index.html')
-        : join(distDir, route.slice(1), 'index.html');
+      // Determine output path. GitHub Pages serves /foo from foo.html without
+      // redirecting to /foo/, which keeps sitemap and canonical URLs aligned.
+      const outputPath = routeToOutputPath(route);
 
       // Create directory if it doesn't exist
       mkdirSync(dirname(outputPath), { recursive: true });

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -187,6 +187,17 @@ async function prerender() {
       console.log(`    ✓ ${redirect.from} → ${redirect.to}`);
     }
 
+    // Build marker the post-deploy smoke check uses to confirm the live site
+    // is actually serving THIS build (and not an older artifact that happens
+    // to satisfy the route shape). The smoke check polls /build-info.json
+    // until the live `sha` matches the local one.
+    const buildInfo = {
+      sha: process.env.GITHUB_SHA ?? 'local',
+      builtAt: new Date().toISOString(),
+    };
+    writeFileSync(join(distDir, 'build-info.json'), `${JSON.stringify(buildInfo, null, 2)}\n`);
+    console.log(`📌 Wrote dist/build-info.json (sha=${buildInfo.sha})`);
+
     console.log('✅ Pre-rendering complete!');
   } catch (error) {
     console.error('❌ Pre-rendering failed:', error);

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -13,17 +13,47 @@ const distDir = join(__dirname, '..', 'dist');
 const blogManifestPath = join(__dirname, '..', 'src', 'generated', 'blog', 'manifest.json');
 const projectsMetaPath = join(__dirname, '..', 'src', 'data', 'projects-meta.json');
 
+// Hardcoded legacy redirects that aren't derivable from the blog manifest.
+// Keep this list small; manifest-driven redirects are preferred.
+const LEGACY_REDIRECTS = [
+  { from: '/projects/andre', to: '/projects/echonest' },
+  { from: '/blog/2026-02-04-andre-collaborative-music-queue', to: '/blog/2026-02-04-echonest-collaborative-music-queue' },
+];
+
 function routeToOutputPath(route) {
   if (route === '/') {
     return join(distDir, 'index.html');
   }
 
   const cleanRoute = route.replace(/^\/+|\/+$/g, '');
-  if (route.endsWith('/')) {
-    return join(distDir, cleanRoute, 'index.html');
-  }
-
   return join(distDir, `${cleanRoute}.html`);
+}
+
+function trailingSlashOutputPath(route) {
+  const cleanRoute = route.replace(/^\/+|\/+$/g, '');
+  return join(distDir, cleanRoute, 'index.html');
+}
+
+function writeRedirectArtifact(outputPath, destination) {
+  // Meta-refresh redirect with canonical link so search engines consolidate
+  // signals on the destination URL. window.location.replace() avoids adding
+  // a history entry so the back button doesn't bounce.
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://dylanbochman.com${destination}">
+  <meta http-equiv="refresh" content="0; url=${destination}">
+  <script>window.location.replace(${JSON.stringify(destination)});</script>
+</head>
+<body>
+  <p>Redirecting to <a href="${destination}">dylanbochman.com${destination}</a>…</p>
+</body>
+</html>
+`;
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, html);
 }
 
 function loadBlogRoutes() {
@@ -72,20 +102,6 @@ async function prerender() {
     const blogRoutes = loadBlogRoutes();
     const projectSlugs = loadPublicProjects().map(p => p.slug);
 
-    // Old routes that redirect to new ones — must be prerendered so GitHub Pages
-    // serves the SPA shell which performs the client-side redirect
-    const redirectRoutes = [
-      '/projects/andre',
-      '/projects/andre/',
-      '/blog/2026-02-04-andre-collaborative-music-queue',
-      '/blog/2026-02-04-andre-collaborative-music-queue/',
-      ...blogRoutes
-        .flatMap(blogRoute => blogRoute.legacyRoute
-          ? [blogRoute.legacyRoute, `${blogRoute.legacyRoute}/`]
-          : []
-        )
-    ];
-
     const routes = [
       '/',
       '/projects',
@@ -94,7 +110,6 @@ async function prerender() {
       '/analytics',
       '/blog',
       ...blogRoutes.map(blogRoute => blogRoute.route),
-      ...redirectRoutes,
     ];
 
     // Routes with persistent network activity (auth, polling) that prevent networkidle
@@ -132,10 +147,35 @@ async function prerender() {
 
     await browser.close();
 
-    // Create redirect files for legacy URLs (Google Search Console 404s)
-    // These are .html files that existed on the old site
-    console.log('🔄 Creating legacy URL redirects...');
-    const legacyRedirects = [
+    // Trailing-slash redirects for every prerendered route. GitHub Pages
+    // serves /foo from foo.html but /foo/ requires foo/index.html — without
+    // these stubs, old indexed or externally-linked trailing-slash URLs 404.
+    console.log('↩  Creating trailing-slash redirects to canonical URLs...');
+    for (const route of routes) {
+      if (route === '/') continue;
+      const outputPath = trailingSlashOutputPath(route);
+      writeRedirectArtifact(outputPath, route);
+      console.log(`    ✓ ${route}/ → ${route}`);
+    }
+
+    // Legacy slug redirects derived from the blog manifest plus a small
+    // hardcoded list for cases the manifest doesn't cover (e.g. project renames).
+    // Both slashless and trailing-slash variants are written so any inbound
+    // shape resolves without a GitHub Pages redirect.
+    console.log('🔄 Creating legacy slug redirects...');
+    const manifestRedirects = blogRoutes
+      .filter(b => b.legacyRoute)
+      .map(b => ({ from: b.legacyRoute, to: b.route }));
+
+    for (const redirect of [...manifestRedirects, ...LEGACY_REDIRECTS]) {
+      writeRedirectArtifact(routeToOutputPath(redirect.from), redirect.to);
+      writeRedirectArtifact(trailingSlashOutputPath(redirect.from), redirect.to);
+      console.log(`    ✓ ${redirect.from} → ${redirect.to}`);
+    }
+
+    // Legacy .html files from the pre-SPA site (Google Search Console 404s).
+    console.log('🔄 Creating legacy .html redirects...');
+    const legacyHtmlRedirects = [
       { from: 'contactme.html', to: '/' },
       { from: 'bretton-woods.html', to: '/' },
       { from: 'eurotrip.html', to: '/' },
@@ -143,23 +183,9 @@ async function prerender() {
       { from: 'golden-gloves.html', to: '/' },
     ];
 
-    for (const redirect of legacyRedirects) {
-      const redirectHtml = `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <title>Redirecting...</title>
-  <link rel="canonical" href="https://dylanbochman.com${redirect.to}">
-  <meta http-equiv="refresh" content="0; url=${redirect.to}">
-  <script>window.location.href = "${redirect.to}";</script>
-</head>
-<body>
-  <p>Redirecting to <a href="${redirect.to}">dylanbochman.com${redirect.to}</a>...</p>
-</body>
-</html>`;
-      const outputPath = join(distDir, redirect.from);
-      writeFileSync(outputPath, redirectHtml);
-      console.log(`    ✓ Created redirect: ${redirect.from} → ${redirect.to}`);
+    for (const redirect of legacyHtmlRedirects) {
+      writeRedirectArtifact(join(distDir, redirect.from), redirect.to);
+      console.log(`    ✓ ${redirect.from} → ${redirect.to}`);
     }
 
     console.log('✅ Pre-rendering complete!');

--- a/scripts/smoke-live-routes.mjs
+++ b/scripts/smoke-live-routes.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// Post-deploy smoke check: probe the live GitHub Pages deployment to verify
+// that canonical slashless URLs serve the real prerendered HTML directly
+// (no 3xx redirect to a trailing-slash variant), and that trailing-slash and
+// legacy URLs serve the meta-refresh redirect artifact pointing at the right
+// canonical target.
+//
+// This is the only place where the assumption baked into prerender.mjs —
+// that GitHub Pages prefers `foo.html` over `foo/index.html` for `/foo` when
+// both exist — is verified against real Pages behavior. If GitHub ever
+// changes that precedence, this check fails the deploy workflow loudly.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const SITE_URL = process.argv[2];
+if (!SITE_URL) {
+  console.error('Usage: smoke-live-routes.mjs <base-url>');
+  process.exit(1);
+}
+
+const seoRedirectsPath = join(process.cwd(), 'src', 'data', 'seo-redirects.json');
+const { legacyRedirects } = JSON.parse(readFileSync(seoRedirectsPath, 'utf8'));
+
+// A representative sample is enough — the GH Pages precedence rule applies
+// uniformly. Spot-check a section root, a content page, and one legacy entry.
+const CANONICAL_ROUTES = [
+  '/',
+  '/blog',
+  '/projects',
+  '/runbook',
+  '/blog/hello-world',
+];
+
+const REDIRECT_ROUTES = [
+  { from: '/blog/', to: '/blog' },
+  { from: '/projects/', to: '/projects' },
+  { from: '/runbook/', to: '/runbook' },
+  { from: '/blog/hello-world/', to: '/blog/hello-world' },
+  ...legacyRedirects.flatMap(({ from, to }) => [
+    { from, to },
+    { from: `${from}/`, to },
+  ]),
+];
+
+const RETRY_ATTEMPTS = 8;
+const RETRY_DELAY_MS = 15_000;
+
+async function fetchOnce(url) {
+  // redirect: 'manual' so we observe any GH Pages-issued 3xx instead of
+  // following it silently. Our static redirect artifacts return 200 with
+  // meta-refresh, not 3xx, so a 3xx here means something went wrong.
+  return fetch(url, { redirect: 'manual', headers: { 'cache-control': 'no-cache' } });
+}
+
+async function fetchWithRetry(url) {
+  let lastErr;
+  for (let i = 0; i < RETRY_ATTEMPTS; i++) {
+    try {
+      const res = await fetchOnce(url);
+      if (res.status >= 500) {
+        lastErr = new Error(`status ${res.status}`);
+      } else {
+        return res;
+      }
+    } catch (err) {
+      lastErr = err;
+    }
+    if (i < RETRY_ATTEMPTS - 1) {
+      await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+    }
+  }
+  throw new Error(`${url}: ${lastErr?.message ?? 'unknown error'}`);
+}
+
+let failures = 0;
+function fail(msg) {
+  console.error(`❌ ${msg}`);
+  failures += 1;
+}
+
+console.log(`🔎 Probing ${SITE_URL} ...`);
+
+for (const route of CANONICAL_ROUTES) {
+  const url = `${SITE_URL}${route}`;
+  const res = await fetchWithRetry(url);
+  if (res.status !== 200) {
+    const loc = res.headers.get('location');
+    fail(`${route} expected 200, got ${res.status}${loc ? ` → ${loc}` : ''}`);
+    continue;
+  }
+  const body = await res.text();
+  if (/<meta\s+http-equiv=["']refresh["']/i.test(body)) {
+    fail(`${route} returned the redirect template; canonical should serve the real prerendered page`);
+    continue;
+  }
+  console.log(`✅ ${route} → 200 (canonical content)`);
+}
+
+for (const { from, to } of REDIRECT_ROUTES) {
+  const url = `${SITE_URL}${from}`;
+  const res = await fetchWithRetry(url);
+  if (res.status !== 200) {
+    const loc = res.headers.get('location');
+    fail(`${from} expected 200 (meta-refresh redirect file), got ${res.status}${loc ? ` → ${loc}` : ''}`);
+    continue;
+  }
+  const body = await res.text();
+  if (!body.includes(`url=${to}`) || !body.includes(`https://dylanbochman.com${to}`)) {
+    fail(`${from} returned 200 but the body does not redirect to ${to}`);
+    continue;
+  }
+  console.log(`✅ ${from} → 200 (redirect to ${to})`);
+}
+
+if (failures) {
+  console.error(`\n❌ ${failures} live route check${failures === 1 ? '' : 's'} failed`);
+  process.exit(1);
+}
+console.log('\n✅ All live route checks passed');

--- a/scripts/smoke-live-routes.mjs
+++ b/scripts/smoke-live-routes.mjs
@@ -37,9 +37,20 @@ const POLL_INTERVAL_MS = 8 * 1000;
 const REDIRECT_META_REGEX = /<meta\s+http-equiv=["']refresh["']/i;
 
 const sitemap = readFileSync(join(distDir, 'sitemap.xml'), 'utf8');
-const sitemapPaths = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map(
-  match => new URL(match[1]).pathname
-);
+const sitemapUrls = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map(match => match[1]);
+const sitemapPaths = sitemapUrls.map(u => new URL(u).pathname);
+
+// Canonical host is whatever the sitemap advertises. Same value all our
+// artifacts hardcode for canonical / og:url tags, so probing localhost
+// (or any non-prod host) still works — we're checking that artifact
+// content points at the canonical, not that SITE_URL equals canonical.
+const expectedCanonicalOrigin = new URL(sitemapUrls[0]).origin;
+
+// Local build marker. The propagation gate below polls the live URL until
+// its build-info.json `sha` matches this value, which guarantees we're
+// checking the artifact this run produced and not a leftover from a
+// previous deploy that happens to satisfy the same route shape.
+const localBuildInfo = JSON.parse(readFileSync(join(distDir, 'build-info.json'), 'utf8'));
 
 const sectionRoots = sitemapPaths.filter(p => /^\/[^/]+$/.test(p));
 const blogPosts = sitemapPaths.filter(p => p.startsWith('/blog/'));
@@ -96,7 +107,7 @@ function canonicalPredicate(res, body) {
 }
 
 function makeRedirectPredicate(target) {
-  const expectedCanonical = `https://dylanbochman.com${target}`;
+  const expectedCanonical = `${expectedCanonicalOrigin}${target}`;
   return (res, body) => {
     if (res.status !== 200) {
       const loc = res.headers.get('location');
@@ -136,18 +147,40 @@ async function pollUntil(url, predicate, timeoutMs) {
 }
 
 console.log(`🔎 Probing ${SITE_URL}`);
+console.log(`   expected build sha:  ${localBuildInfo.sha}`);
+console.log(`   canonical origin:    ${expectedCanonicalOrigin}`);
 console.log(`   sample blog post:    ${sampleBlogRoute}`);
 if (sampleProjectRoute) console.log(`   sample project page: ${sampleProjectRoute}`);
 
-// Step 1: wait for propagation by polling `/` until it returns the real page.
-// Once `/` is good, the rest of the deploy is almost certainly visible too.
-console.log('⏳ Waiting for propagation...');
-const propagation = await pollUntil(`${SITE_URL}/`, canonicalPredicate, PROPAGATION_TIMEOUT_MS);
+// Step 1: gate on /build-info.json reporting THIS build's SHA. Polling for
+// SHA match (rather than "did / return some real page") catches the case
+// where Pages still serves the previous deploy, which would otherwise pass
+// a content-shape check on stable routes.
+console.log('⏳ Waiting for new build to propagate...');
+const propagation = await pollUntil(
+  `${SITE_URL}/build-info.json`,
+  (res, body) => {
+    if (res.status !== 200) {
+      return { ok: false, reason: `build-info.json status ${res.status}` };
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(body);
+    } catch (err) {
+      return { ok: false, reason: `build-info.json is not valid JSON: ${err.message}` };
+    }
+    if (parsed.sha !== localBuildInfo.sha) {
+      return { ok: false, reason: `live sha=${parsed.sha} (expected ${localBuildInfo.sha})` };
+    }
+    return { ok: true };
+  },
+  PROPAGATION_TIMEOUT_MS
+);
 if (!propagation.ok) {
-  console.error(`❌ Propagation timeout: / never returned canonical content (${propagation.reason})`);
+  console.error(`❌ Propagation timeout: live build never matched local sha (${propagation.reason})`);
   process.exit(1);
 }
-console.log('✅ Propagation observed at /');
+console.log(`✅ Live build matches local sha ${localBuildInfo.sha}`);
 
 // Step 2: check every route in parallel with a shorter per-route budget.
 // Parallel keeps total wall time bounded even with many routes.

--- a/scripts/smoke-live-routes.mjs
+++ b/scripts/smoke-live-routes.mjs
@@ -9,108 +9,177 @@
 // that GitHub Pages prefers `foo.html` over `foo/index.html` for `/foo` when
 // both exist — is verified against real Pages behavior. If GitHub ever
 // changes that precedence, this check fails the deploy workflow loudly.
+//
+// Sample routes are derived from dist/sitemap.xml so a renamed or drafted
+// post doesn't become a deploy blocker. Legacy redirect routes come from
+// src/data/seo-redirects.json — the same source prerender.mjs and
+// verify-seo-routes.mjs read, so the three stay aligned.
 
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 
-const SITE_URL = process.argv[2];
+const SITE_URL = (process.argv[2] ?? '').replace(/\/+$/, '');
+const distDir = resolve(process.argv[3] ?? 'dist');
+const redirectsPath = resolve(process.argv[4] ?? join('src', 'data', 'seo-redirects.json'));
+
 if (!SITE_URL) {
-  console.error('Usage: smoke-live-routes.mjs <base-url>');
+  console.error('Usage: smoke-live-routes.mjs <base-url> [dist-dir] [redirects-json]');
   process.exit(1);
 }
 
-const seoRedirectsPath = join(process.cwd(), 'src', 'data', 'seo-redirects.json');
-const { legacyRedirects } = JSON.parse(readFileSync(seoRedirectsPath, 'utf8'));
+// Polling budgets. The propagation wait covers GitHub Pages rebuilding plus
+// any CDN cache replacement. Per-route timeouts handle cache lag on
+// individual URLs after propagation has otherwise completed.
+const PROPAGATION_TIMEOUT_MS = 5 * 60 * 1000;
+const ROUTE_TIMEOUT_MS = 90 * 1000;
+const POLL_INTERVAL_MS = 8 * 1000;
 
-// A representative sample is enough — the GH Pages precedence rule applies
-// uniformly. Spot-check a section root, a content page, and one legacy entry.
-const CANONICAL_ROUTES = [
+const REDIRECT_META_REGEX = /<meta\s+http-equiv=["']refresh["']/i;
+
+const sitemap = readFileSync(join(distDir, 'sitemap.xml'), 'utf8');
+const sitemapPaths = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map(
+  match => new URL(match[1]).pathname
+);
+
+const sectionRoots = sitemapPaths.filter(p => /^\/[^/]+$/.test(p));
+const blogPosts = sitemapPaths.filter(p => p.startsWith('/blog/'));
+const projectPages = sitemapPaths.filter(p => p.startsWith('/projects/'));
+
+if (blogPosts.length === 0) {
+  console.error('No /blog/<slug> entries in sitemap to sample from');
+  process.exit(1);
+}
+
+// Alphabetical pick is stable across renames/drafts of unrelated posts.
+const sampleBlogRoute = [...blogPosts].sort()[0];
+const sampleProjectRoute = projectPages.length > 0 ? [...projectPages].sort()[0] : null;
+
+const canonicalRoutes = Array.from(new Set([
   '/',
-  '/blog',
-  '/projects',
-  '/runbook',
-  '/blog/hello-world',
-];
+  ...sectionRoots,
+  sampleBlogRoute,
+  ...(sampleProjectRoute ? [sampleProjectRoute] : []),
+]));
 
-const REDIRECT_ROUTES = [
-  { from: '/blog/', to: '/blog' },
-  { from: '/projects/', to: '/projects' },
-  { from: '/runbook/', to: '/runbook' },
-  { from: '/blog/hello-world/', to: '/blog/hello-world' },
+const { legacyRedirects } = JSON.parse(readFileSync(redirectsPath, 'utf8'));
+
+const redirectRoutes = [
+  ...sectionRoots.map(r => ({ from: `${r}/`, to: r })),
+  { from: `${sampleBlogRoute}/`, to: sampleBlogRoute },
+  ...(sampleProjectRoute ? [{ from: `${sampleProjectRoute}/`, to: sampleProjectRoute }] : []),
   ...legacyRedirects.flatMap(({ from, to }) => [
     { from, to },
     { from: `${from}/`, to },
   ]),
 ];
 
-const RETRY_ATTEMPTS = 8;
-const RETRY_DELAY_MS = 15_000;
-
-async function fetchOnce(url) {
-  // redirect: 'manual' so we observe any GH Pages-issued 3xx instead of
-  // following it silently. Our static redirect artifacts return 200 with
-  // meta-refresh, not 3xx, so a 3xx here means something went wrong.
-  return fetch(url, { redirect: 'manual', headers: { 'cache-control': 'no-cache' } });
+async function fetchRoute(url) {
+  // redirect: 'manual' surfaces any GH Pages-issued 3xx instead of following
+  // it silently. cache: no-store + cache-control headers reduce the chance
+  // of seeing a stale edge-cached body during a deploy.
+  return fetch(url, {
+    redirect: 'manual',
+    cache: 'no-store',
+    headers: { 'cache-control': 'no-cache', pragma: 'no-cache' },
+  });
 }
 
-async function fetchWithRetry(url) {
-  let lastErr;
-  for (let i = 0; i < RETRY_ATTEMPTS; i++) {
-    try {
-      const res = await fetchOnce(url);
-      if (res.status >= 500) {
-        lastErr = new Error(`status ${res.status}`);
-      } else {
-        return res;
-      }
-    } catch (err) {
-      lastErr = err;
-    }
-    if (i < RETRY_ATTEMPTS - 1) {
-      await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
-    }
+function canonicalPredicate(res, body) {
+  if (res.status !== 200) {
+    const loc = res.headers.get('location');
+    return { ok: false, reason: `status ${res.status}${loc ? ` → ${loc}` : ''}` };
   }
-  throw new Error(`${url}: ${lastErr?.message ?? 'unknown error'}`);
+  if (REDIRECT_META_REGEX.test(body)) {
+    return { ok: false, reason: 'returned meta-refresh template (expected real prerendered page)' };
+  }
+  return { ok: true };
 }
+
+function makeRedirectPredicate(target) {
+  const expectedCanonical = `https://dylanbochman.com${target}`;
+  return (res, body) => {
+    if (res.status !== 200) {
+      const loc = res.headers.get('location');
+      return { ok: false, reason: `status ${res.status}${loc ? ` → ${loc}` : ''}` };
+    }
+    if (!REDIRECT_META_REGEX.test(body)) {
+      return { ok: false, reason: 'expected meta-refresh redirect, got real page content' };
+    }
+    if (!body.includes(`url=${target}`) || !body.includes(expectedCanonical)) {
+      return { ok: false, reason: `body does not redirect to ${target}` };
+    }
+    return { ok: true };
+  };
+}
+
+// Polls a URL with no-cache headers until the predicate accepts the response
+// or the timeout elapses. Any error (network, 4xx, 5xx, stale body) triggers
+// another poll rather than an immediate fail — exactly what's needed while
+// GitHub Pages and any CDN edge swap in the new deploy.
+async function pollUntil(url, predicate, timeoutMs) {
+  const start = Date.now();
+  let last = { ok: false, reason: 'no response yet' };
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetchRoute(url);
+      const body = res.status === 200 ? await res.text() : '';
+      last = predicate(res, body);
+      if (last.ok) return last;
+    } catch (err) {
+      last = { ok: false, reason: err.message };
+    }
+    const remaining = timeoutMs - (Date.now() - start);
+    if (remaining <= 0) break;
+    await new Promise(r => setTimeout(r, Math.min(POLL_INTERVAL_MS, remaining)));
+  }
+  return last;
+}
+
+console.log(`🔎 Probing ${SITE_URL}`);
+console.log(`   sample blog post:    ${sampleBlogRoute}`);
+if (sampleProjectRoute) console.log(`   sample project page: ${sampleProjectRoute}`);
+
+// Step 1: wait for propagation by polling `/` until it returns the real page.
+// Once `/` is good, the rest of the deploy is almost certainly visible too.
+console.log('⏳ Waiting for propagation...');
+const propagation = await pollUntil(`${SITE_URL}/`, canonicalPredicate, PROPAGATION_TIMEOUT_MS);
+if (!propagation.ok) {
+  console.error(`❌ Propagation timeout: / never returned canonical content (${propagation.reason})`);
+  process.exit(1);
+}
+console.log('✅ Propagation observed at /');
+
+// Step 2: check every route in parallel with a shorter per-route budget.
+// Parallel keeps total wall time bounded even with many routes.
+const canonicalResults = await Promise.all(
+  canonicalRoutes.map(route =>
+    pollUntil(`${SITE_URL}${route}`, canonicalPredicate, ROUTE_TIMEOUT_MS)
+      .then(r => ({ route, r }))
+  )
+);
+const redirectResults = await Promise.all(
+  redirectRoutes.map(({ from, to }) =>
+    pollUntil(`${SITE_URL}${from}`, makeRedirectPredicate(to), ROUTE_TIMEOUT_MS)
+      .then(r => ({ route: from, to, r }))
+  )
+);
 
 let failures = 0;
-function fail(msg) {
-  console.error(`❌ ${msg}`);
-  failures += 1;
+for (const { route, r } of canonicalResults) {
+  if (r.ok) {
+    console.log(`✅ ${route} → canonical content`);
+  } else {
+    console.error(`❌ ${route} → ${r.reason}`);
+    failures += 1;
+  }
 }
-
-console.log(`🔎 Probing ${SITE_URL} ...`);
-
-for (const route of CANONICAL_ROUTES) {
-  const url = `${SITE_URL}${route}`;
-  const res = await fetchWithRetry(url);
-  if (res.status !== 200) {
-    const loc = res.headers.get('location');
-    fail(`${route} expected 200, got ${res.status}${loc ? ` → ${loc}` : ''}`);
-    continue;
+for (const { route, to, r } of redirectResults) {
+  if (r.ok) {
+    console.log(`✅ ${route} → redirect to ${to}`);
+  } else {
+    console.error(`❌ ${route} → ${r.reason}`);
+    failures += 1;
   }
-  const body = await res.text();
-  if (/<meta\s+http-equiv=["']refresh["']/i.test(body)) {
-    fail(`${route} returned the redirect template; canonical should serve the real prerendered page`);
-    continue;
-  }
-  console.log(`✅ ${route} → 200 (canonical content)`);
-}
-
-for (const { from, to } of REDIRECT_ROUTES) {
-  const url = `${SITE_URL}${from}`;
-  const res = await fetchWithRetry(url);
-  if (res.status !== 200) {
-    const loc = res.headers.get('location');
-    fail(`${from} expected 200 (meta-refresh redirect file), got ${res.status}${loc ? ` → ${loc}` : ''}`);
-    continue;
-  }
-  const body = await res.text();
-  if (!body.includes(`url=${to}`) || !body.includes(`https://dylanbochman.com${to}`)) {
-    fail(`${from} returned 200 but the body does not redirect to ${to}`);
-    continue;
-  }
-  console.log(`✅ ${from} → 200 (redirect to ${to})`);
 }
 
 if (failures) {

--- a/scripts/verify-seo-routes.mjs
+++ b/scripts/verify-seo-routes.mjs
@@ -7,42 +7,69 @@ const distDir = join(process.cwd(), 'dist');
 const sitemapPath = join(distDir, 'sitemap.xml');
 const blogManifestPath = join(process.cwd(), 'src', 'generated', 'blog', 'manifest.json');
 
+// Must stay in sync with LEGACY_REDIRECTS in scripts/prerender.mjs.
+const HARDCODED_LEGACY_REDIRECTS = [
+  { from: '/projects/andre', to: '/projects/echonest' },
+  { from: '/blog/2026-02-04-andre-collaborative-music-queue', to: '/blog/2026-02-04-echonest-collaborative-music-queue' },
+];
+
+const MIN_CANONICAL_SIZE = 10_000;
+
 function fail(message) {
   console.error(`❌ ${message}`);
   process.exitCode = 1;
 }
 
-function artifactForPath(pathname) {
+function canonicalArtifactPath(pathname) {
   if (pathname === '/') {
     return join(distDir, 'index.html');
   }
-
   return join(distDir, `${pathname.replace(/^\/+|\/+$/g, '')}.html`);
 }
 
-function trailingSlashArtifactForPath(pathname) {
+function trailingSlashArtifactPath(pathname) {
   return join(distDir, pathname.replace(/^\/+|\/+$/g, ''), 'index.html');
 }
 
-function legacyTrailingSlashPaths() {
-  const paths = [
-    '/projects/andre/',
-    '/blog/2026-02-04-andre-collaborative-music-queue/',
-  ];
-
-  if (!existsSync(blogManifestPath)) {
-    return paths;
+function assertRedirectArtifact(artifactPath, expectedTarget, label) {
+  if (!existsSync(artifactPath)) {
+    fail(`${label} missing: ${artifactPath}`);
+    return;
   }
 
+  const contents = readFileSync(artifactPath, 'utf8');
+  const expectedCanonical = `https://dylanbochman.com${expectedTarget}`;
+
+  if (!contents.includes(`<link rel="canonical" href="${expectedCanonical}">`)) {
+    fail(`${label} (${artifactPath}) is missing canonical link to ${expectedCanonical}`);
+  }
+  if (!contents.includes(`url=${expectedTarget}`)) {
+    fail(`${label} (${artifactPath}) is missing meta-refresh to ${expectedTarget}`);
+  }
+}
+
+function assertCanonicalArtifact(artifactPath, label) {
+  if (!existsSync(artifactPath)) {
+    fail(`${label} missing: ${artifactPath}`);
+    return;
+  }
+  if (statSync(artifactPath).size < MIN_CANONICAL_SIZE) {
+    fail(`${label} looks too small (likely a redirect, not the real page): ${artifactPath}`);
+  }
+}
+
+function manifestLegacyRedirects() {
+  if (!existsSync(blogManifestPath)) return [];
+
   const manifest = JSON.parse(readFileSync(blogManifestPath, 'utf8'));
+  const redirects = [];
   for (const [filenameSlug, entry] of Object.entries(manifest)) {
     const canonicalSlug = entry.frontmatter.slug;
     if (!entry.frontmatter.draft && canonicalSlug && canonicalSlug !== filenameSlug) {
-      paths.push(`/blog/${filenameSlug}/`);
+      redirects.push({ from: `/blog/${filenameSlug}`, to: `/blog/${canonicalSlug}` });
     }
   }
-
-  return paths;
+  return redirects;
 }
 
 if (!existsSync(sitemapPath)) {
@@ -55,6 +82,7 @@ if (!existsSync(sitemapPath)) {
     fail('dist/sitemap.xml does not contain any <loc> entries.');
   }
 
+  let trailingSlashChecks = 0;
   for (const url of urls) {
     if (!url.startsWith(SITE_URL)) {
       fail(`Unexpected sitemap host: ${url}`);
@@ -67,33 +95,38 @@ if (!existsSync(sitemapPath)) {
       fail(`Sitemap URL should be slashless to avoid GitHub Pages directory redirects: ${url}`);
     }
 
-    const artifactPath = artifactForPath(pathname);
+    assertCanonicalArtifact(canonicalArtifactPath(pathname), `Sitemap canonical artifact for ${url}`);
 
-    if (!existsSync(artifactPath)) {
-      fail(`Sitemap URL has no matching prerendered artifact: ${url} -> ${artifactPath}`);
-      continue;
-    }
-
-    if (statSync(artifactPath).size < 10_000) {
-      fail(`Prerendered artifact looks too small: ${artifactPath}`);
+    // Every non-root sitemap route also needs a trailing-slash redirect artifact.
+    // Without it, GitHub Pages returns 404 for inbound /foo/ URLs (it serves
+    // foo.html for /foo but does not fall back to foo.html for /foo/).
+    if (pathname !== '/') {
+      assertRedirectArtifact(
+        trailingSlashArtifactPath(pathname),
+        pathname,
+        `Trailing-slash redirect for ${url}`
+      );
+      trailingSlashChecks += 1;
     }
   }
 
-  const legacyPaths = legacyTrailingSlashPaths();
-  for (const pathname of legacyPaths) {
-    const artifactPath = trailingSlashArtifactForPath(pathname);
-
-    if (!existsSync(artifactPath)) {
-      fail(`Legacy trailing-slash redirect route has no matching artifact: ${pathname} -> ${artifactPath}`);
-      continue;
-    }
-
-    if (statSync(artifactPath).size < 10_000) {
-      fail(`Legacy redirect artifact looks too small: ${artifactPath}`);
-    }
+  const legacyRedirects = [...manifestLegacyRedirects(), ...HARDCODED_LEGACY_REDIRECTS];
+  for (const { from, to } of legacyRedirects) {
+    assertRedirectArtifact(
+      canonicalArtifactPath(from),
+      to,
+      `Legacy slashless redirect ${from} → ${to}`
+    );
+    assertRedirectArtifact(
+      trailingSlashArtifactPath(from),
+      to,
+      `Legacy trailing-slash redirect ${from}/ → ${to}`
+    );
   }
 
   if (!process.exitCode) {
-    console.log(`✅ Verified ${urls.length} sitemap URLs and ${legacyPaths.length} legacy trailing-slash routes have matching prerendered artifacts`);
+    console.log(
+      `✅ Verified ${urls.length} sitemap canonicals, ${trailingSlashChecks} trailing-slash redirects, and ${legacyRedirects.length} legacy slug redirects`
+    );
   }
 }

--- a/scripts/verify-seo-routes.mjs
+++ b/scripts/verify-seo-routes.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+const SITE_URL = 'https://dylanbochman.com';
+const distDir = join(process.cwd(), 'dist');
+const sitemapPath = join(distDir, 'sitemap.xml');
+const blogManifestPath = join(process.cwd(), 'src', 'generated', 'blog', 'manifest.json');
+
+function fail(message) {
+  console.error(`❌ ${message}`);
+  process.exitCode = 1;
+}
+
+function artifactForPath(pathname) {
+  if (pathname === '/') {
+    return join(distDir, 'index.html');
+  }
+
+  return join(distDir, `${pathname.replace(/^\/+|\/+$/g, '')}.html`);
+}
+
+function trailingSlashArtifactForPath(pathname) {
+  return join(distDir, pathname.replace(/^\/+|\/+$/g, ''), 'index.html');
+}
+
+function legacyTrailingSlashPaths() {
+  const paths = [
+    '/projects/andre/',
+    '/blog/2026-02-04-andre-collaborative-music-queue/',
+  ];
+
+  if (!existsSync(blogManifestPath)) {
+    return paths;
+  }
+
+  const manifest = JSON.parse(readFileSync(blogManifestPath, 'utf8'));
+  for (const [filenameSlug, entry] of Object.entries(manifest)) {
+    const canonicalSlug = entry.frontmatter.slug;
+    if (!entry.frontmatter.draft && canonicalSlug && canonicalSlug !== filenameSlug) {
+      paths.push(`/blog/${filenameSlug}/`);
+    }
+  }
+
+  return paths;
+}
+
+if (!existsSync(sitemapPath)) {
+  fail('dist/sitemap.xml is missing. Run npm run build first.');
+} else {
+  const sitemap = readFileSync(sitemapPath, 'utf8');
+  const urls = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map(match => match[1]);
+
+  if (urls.length === 0) {
+    fail('dist/sitemap.xml does not contain any <loc> entries.');
+  }
+
+  for (const url of urls) {
+    if (!url.startsWith(SITE_URL)) {
+      fail(`Unexpected sitemap host: ${url}`);
+      continue;
+    }
+
+    const { pathname } = new URL(url);
+
+    if (pathname !== '/' && pathname.endsWith('/')) {
+      fail(`Sitemap URL should be slashless to avoid GitHub Pages directory redirects: ${url}`);
+    }
+
+    const artifactPath = artifactForPath(pathname);
+
+    if (!existsSync(artifactPath)) {
+      fail(`Sitemap URL has no matching prerendered artifact: ${url} -> ${artifactPath}`);
+      continue;
+    }
+
+    if (statSync(artifactPath).size < 10_000) {
+      fail(`Prerendered artifact looks too small: ${artifactPath}`);
+    }
+  }
+
+  const legacyPaths = legacyTrailingSlashPaths();
+  for (const pathname of legacyPaths) {
+    const artifactPath = trailingSlashArtifactForPath(pathname);
+
+    if (!existsSync(artifactPath)) {
+      fail(`Legacy trailing-slash redirect route has no matching artifact: ${pathname} -> ${artifactPath}`);
+      continue;
+    }
+
+    if (statSync(artifactPath).size < 10_000) {
+      fail(`Legacy redirect artifact looks too small: ${artifactPath}`);
+    }
+  }
+
+  if (!process.exitCode) {
+    console.log(`✅ Verified ${urls.length} sitemap URLs and ${legacyPaths.length} legacy trailing-slash routes have matching prerendered artifacts`);
+  }
+}

--- a/scripts/verify-seo-routes.mjs
+++ b/scripts/verify-seo-routes.mjs
@@ -6,12 +6,11 @@ const SITE_URL = 'https://dylanbochman.com';
 const distDir = join(process.cwd(), 'dist');
 const sitemapPath = join(distDir, 'sitemap.xml');
 const blogManifestPath = join(process.cwd(), 'src', 'generated', 'blog', 'manifest.json');
+const seoRedirectsPath = join(process.cwd(), 'src', 'data', 'seo-redirects.json');
 
-// Must stay in sync with LEGACY_REDIRECTS in scripts/prerender.mjs.
-const HARDCODED_LEGACY_REDIRECTS = [
-  { from: '/projects/andre', to: '/projects/echonest' },
-  { from: '/blog/2026-02-04-andre-collaborative-music-queue', to: '/blog/2026-02-04-echonest-collaborative-music-queue' },
-];
+const { legacyRedirects: HARDCODED_LEGACY_REDIRECTS } = JSON.parse(
+  readFileSync(seoRedirectsPath, 'utf8')
+);
 
 const MIN_CANONICAL_SIZE = 10_000;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,10 @@ const App = () => (
                     <Route path="/projects/andre/" element={<Navigate to="/projects/echonest" replace />} />
                     <Route path="/blog/2026-02-04-andre-collaborative-music-queue" element={<Navigate to="/blog/2026-02-04-echonest-collaborative-music-queue" replace />} />
                     <Route path="/blog/2026-02-04-andre-collaborative-music-queue/" element={<Navigate to="/blog/2026-02-04-echonest-collaborative-music-queue" replace />} />
+                    <Route path="/blog/2026-01-04-hello-world" element={<Navigate to="/blog/hello-world" replace />} />
+                    <Route path="/blog/2026-01-04-hello-world/" element={<Navigate to="/blog/hello-world" replace />} />
+                    <Route path="/blog/2026-01-07-writing-a-runbook-for-my-personal-website" element={<Navigate to="/blog/writing-a-runbook-for-my-personal-website" replace />} />
+                    <Route path="/blog/2026-01-07-writing-a-runbook-for-my-personal-website/" element={<Navigate to="/blog/writing-a-runbook-for-my-personal-website" replace />} />
                     {/* Unlisted routes - accessible via URL but not in nav */}
                     <Route path="/projects/house" element={<HouseKanban />} />
                     {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,10 +69,7 @@ const App = () => (
                     <Route path="/projects/andre/" element={<Navigate to="/projects/echonest" replace />} />
                     <Route path="/blog/2026-02-04-andre-collaborative-music-queue" element={<Navigate to="/blog/2026-02-04-echonest-collaborative-music-queue" replace />} />
                     <Route path="/blog/2026-02-04-andre-collaborative-music-queue/" element={<Navigate to="/blog/2026-02-04-echonest-collaborative-music-queue" replace />} />
-                    <Route path="/blog/2026-01-04-hello-world" element={<Navigate to="/blog/hello-world" replace />} />
-                    <Route path="/blog/2026-01-04-hello-world/" element={<Navigate to="/blog/hello-world" replace />} />
-                    <Route path="/blog/2026-01-07-writing-a-runbook-for-my-personal-website" element={<Navigate to="/blog/writing-a-runbook-for-my-personal-website" replace />} />
-                    <Route path="/blog/2026-01-07-writing-a-runbook-for-my-personal-website/" element={<Navigate to="/blog/writing-a-runbook-for-my-personal-website" replace />} />
+                    {/* Manifest-driven legacy blog-slug aliases are handled by static meta-refresh files written in scripts/prerender.mjs — don't add per-post entries here. */}
                     {/* Unlisted routes - accessible via URL but not in nav */}
                     <Route path="/projects/house" element={<HouseKanban />} />
                     {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/Seo.test.tsx
+++ b/src/components/Seo.test.tsx
@@ -26,6 +26,10 @@ describe('Seo', () => {
         meta.remove()
       }
     })
+
+    document.querySelectorAll('link[rel="canonical"]').forEach(link => {
+      link.remove()
+    })
   })
 
   it('should render title with site name', async () => {
@@ -107,6 +111,16 @@ describe('Seo', () => {
       expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe(`${title} | Dylan Bochman`)
       expect(document.querySelector('meta[property="og:description"]')?.getAttribute('content')).toBe(description)
       expect(document.querySelector('meta[property="og:image"]')?.getAttribute('content')).toBe('https://dylanbochman.com/social-preview.webp')
+    })
+  })
+
+  it('should render canonical URL', async () => {
+    renderWithHelmet(
+      <Seo title="Test Page" description="Test description" url="/test-page" />
+    )
+
+    await waitFor(() => {
+      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe('https://dylanbochman.com/test-page')
     })
   })
 

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -45,6 +45,7 @@ const Seo = ({ title, description, imageUrl, url, keywords }: SeoProps) => {
       <title>{fullTitle}</title>
       <meta name="description" content={description} />
       <meta name="keywords" content={keywordsString} />
+      <link rel="canonical" href={fullUrl} />
 
       {/* Open Graph / Facebook */}
       <meta property="og:type" content="website" />

--- a/src/data/seo-redirects.json
+++ b/src/data/seo-redirects.json
@@ -1,0 +1,6 @@
+{
+  "legacyRedirects": [
+    { "from": "/projects/andre", "to": "/projects/echonest" },
+    { "from": "/blog/2026-02-04-andre-collaborative-music-queue", "to": "/blog/2026-02-04-echonest-collaborative-music-queue" }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes the route generation issues behind the Search Console indexing buckets by aligning sitemap URLs, prerendered artifacts, and canonical tags.

- prerender sitemap-facing routes as slashless `.html` files for GitHub Pages
- use the generated blog manifest so custom slugs receive real prerendered pages
- omit draft projects from the sitemap
- move canonical URL generation into the React SEO component to avoid duplicate/root canonicals
- add a deploy-time SEO route verifier

## Root Cause

The sitemap advertised canonical slashless URLs, including custom blog slugs, while the prerender step generated directory `index.html` files from filename slugs. On GitHub Pages that produced redirects for many canonical URLs and 404s for custom slugs such as `/blog/hello-world`. The static shell also stamped every prerendered page with a root canonical before React added the page canonical.

## Validation

- `npm run build`
- `npm run verify-seo-routes`
- `npm run lint`
- `npm test -- --run src/components/Seo.test.tsx`
