### PR TITLE
fix(seo): redirect stale 2025 blog URLs + align home canonical [skip-review]

### DIFF
--- a/src/data/seo-redirects.json
+++ b/src/data/seo-redirects.json
@@ -1,6 +1,11 @@
 {
   "legacyRedirects": [
     { "from": "/projects/andre", "to": "/projects/echonest" },
-    { "from": "/blog/2026-02-04-andre-collaborative-music-queue", "to": "/blog/2026-02-04-echonest-collaborative-music-queue" }
+    { "from": "/blog/2026-02-04-andre-collaborative-music-queue", "to": "/blog/2026-02-04-echonest-collaborative-music-queue" },
+    { "from": "/blog/2025-01-04-hello-world", "to": "/blog/hello-world" },
+    { "from": "/blog/2025-01-05-notes-on-building-this-site-together", "to": "/blog/2026-01-05-notes-on-building-this-site-together" },
+    { "from": "/blog/2025-01-07-uptime-monitoring-for-a-personal-site", "to": "/blog/2026-01-07-uptime-monitoring-for-a-personal-site" },
+    { "from": "/blog/2025-01-07-writing-a-runbook-for-my-personal-website", "to": "/blog/writing-a-runbook-for-my-personal-website" },
+    { "from": "/blog/2025-01-08-fixing-404-errors-on-github-pages-spas", "to": "/blog/2026-01-08-fixing-404-errors-on-github-pages-spas" }
   ]
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -23,6 +23,7 @@ const Index = () => {
         title="Sr. Site Reliability Engineer - Technical Incident Manager"
         description="Specializing in Reliability, Resilience, and Incident Management, with experience spanning SRE and Product Management at Nvidia, Groq, HashiCorp, and Spotify."
         keywords={coreExpertise.map(item => item.title)}
+        url="/"
       />
       <PageLayout>
         {/* Hero Section */}


### PR DESCRIPTION
## Summary

Search Console diagnostic surfaced two real issues after PR #301 deployed:

- 5 blog posts had legacy `2025-MM-DD-*` URLs that were renamed to `2026-MM-DD-*` without redirects, so 3+ were genuine 404s in the **Not Found (404)** bucket.
- Home-page `<Seo>` didn't pass a `url` prop, so the rendered canonical was `https://dylanbochman.com` (no trailing slash) while the sitemap has `https://dylanbochman.com/`. The mismatch is the most likely reason `/index.html` variants landed in the **Soft 404** bucket.

## Changes

- Add 5 entries to `src/data/seo-redirects.json` mapping each legacy `2025-MM-DD-*` URL to its 2026 counterpart (canonical slug where applicable).
- Pass `url="/"` to `<Seo>` on the Index page so the home canonical matches the sitemap exactly.

## Validation

- `npm run build` — new redirect artifacts generated for both slashless and trailing-slash shapes
- `npm run verify-seo-routes` — passes (9 legacy redirects, was 4)
- `npm run lint` — clean

## Test plan

- [ ] CI green (build-and-test, deploy, verify-live)
- [ ] After deploy, `curl -I https://dylanbochman.com/blog/2025-01-07-uptime-monitoring-for-a-personal-site` returns 200 with meta-refresh to `/blog/2026-01-07-uptime-monitoring-for-a-personal-site`
- [ ] After deploy, `curl -s https://dylanbochman.com/ | grep canonical` shows trailing slash
- [ ] In Search Console: re-trigger Validate Fix on Not Found (404). Soft 404 may also benefit once Enforce HTTPS is enabled in repo Pages settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)