### PR TITLE
docs(cloudflare): clarify _redirects scope, document production Redirect Rule

### DIFF
--- a/docs/OPERATIONS_MANUAL.md
+++ b/docs/OPERATIONS_MANUAL.md
@@ -102,6 +102,11 @@ No manual steps needed. Check [Actions tab](https://github.com/Dbochman/personal
   - CNAME `@` → dbochman.github.io (main site)
   - (api subdomain managed automatically by Worker Custom Domain)
 
+**Redirect Rules (zone dylanbochman.com → Rules → Redirect Rules):**
+- **Rule:** "Legacy .html → home (soft 404 fix)" (created 2026-06-10)
+- 301-redirects `/index.html`, `/contactme.html`, `/bretton-woods.html`, `/eurotrip.html`, `/photography.html`, `/golden-gloves.html` → `https://dylanbochman.com/`
+- This is the **production** fix for soft 404s on legacy URLs. `public/_redirects` does NOT apply to production (it's a Cloudflare Pages feature, so it only affects branch previews on `*.personal-website-adg.pages.dev`); it mirrors this rule to keep previews consistent.
+
 **Pages Project (Preview Deployments):**
 - **Project name:** personal-website-adg
 - **URL:** https://personal-website-adg.pages.dev

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,11 @@
-# Cloudflare Pages redirects
-# Redirect /index.html to / (canonical URL) to fix soft 404s
+# Cloudflare Pages redirects — PREVIEW DEPLOYMENTS ONLY
+#
+# Production (dylanbochman.com) is GitHub Pages behind the Cloudflare proxy,
+# so this file has NO effect there. The production redirects for these paths
+# live in a Cloudflare Redirect Rule named "Legacy .html → home (soft 404 fix)"
+# (zone dylanbochman.com → Rules → Redirect Rules). This file only keeps
+# branch previews (*.personal-website-adg.pages.dev) consistent with prod.
+
 /index.html / 301
 
 # Legacy .html files from old site - redirect to homepage


### PR DESCRIPTION
## Summary
- `public/_redirects` claimed to redirect `/index.html` → `/` "to fix soft 404s", but production is GitHub Pages behind the Cloudflare proxy — `_redirects` is a Cloudflare Pages feature and only applies to branch previews (`*.personal-website-adg.pages.dev`). Rewrote the comment to say so and point at the real production fix.
- Documented the Cloudflare Redirect Rule **"Legacy .html → home (soft 404 fix)"** (zone dylanbochman.com → Rules → Redirect Rules, created 2026-06-10) in `docs/OPERATIONS_MANUAL.md` under the Cloudflare section. It 301s `/index.html` and five legacy `.html` pages to `https://dylanbochman.com/`.

Docs/comments only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)