### PR TITLE
fix(seo): single meta description per page + query-informed Decap snippet

### DIFF
--- a/.claude/session-notes.md
+++ b/.claude/session-notes.md
@@ -428,3 +428,29 @@ Drew from the security plan to flesh out the blog post's security section. Added
 Key addition: a paragraph about the two layers of guardrails (infrastructure vs instruction) and being honest about the difference in the blog post.
 
 ---
+
+---
+
+## 2026-06-10: GSC Indexing Audit — _redirects Doesn't Apply to Production
+
+**Key realization:** `public/_redirects` (added to fix the `/index.html` soft 404) is a Cloudflare Pages convention — but production is GitHub Pages behind the Cloudflare proxy. The file only affects branch previews. `https://dylanbochman.com/index.html` still returns 200 with homepage content, which is why GSC's Soft 404 validation failed on 6/1/26.
+
+**Fix requires a Cloudflare Redirect Rule** (dashboard → Rules → Redirect Rules), not a repo change. Single rule can cover /index.html + the 5 legacy .html paths.
+
+**Other findings:**
+- All 42 sitemap URLs: 200, prerendered, correct self-canonicals. On-page SEO is healthy.
+- Indexed-page drop ~5/5→5/8 matches the prerender deploy regression fixed in 4c051b0 (May 8). Recovery is organic, weeks-scale.
+- Legacy/trailing-slash stubs (meta-refresh + canonical) verified working live.
+**Resolution (same day):** Cloudflare Redirect Rule "Legacy .html → home (soft 404 fix)" created and verified live — /index.html + 5 legacy .html paths all 301 → / in one hop, on apex and www, no loop. New GSC Soft 404 validation kicked off and sitemap resubmitted 6/10/26.
+
+---
+
+## 2026-06-10 (cont): Mermaid Preload Fix + Playwright CDN Incident
+
+**Perf (PR #307):** Homepage was modulepreloading the 697KB-compressed mermaid chunk on every page despite mermaid being dynamically imported. Root cause: Rollup placed Vite's virtual preload-helper module inside the manualChunks 'mermaid' chunk, so the entry statically imported mermaid just to reach the helper. Fix: pin `vite/preload-helper` to 'vendor' in manualChunks. Live result: 917KB → 215KB compressed JS on homepage (-77%). Watch RUM FCP/LCP (was 29% good / 3.2s avg) over the next week.
+
+**Pattern:** With a manualChunks function, ALWAYS handle Vite's virtual helper modules (`\0vite/preload-helper`) explicitly — unassigned, Rollup can drop them into any chunk and chain it into the entry graph.
+
+**CI incident:** Playwright CDN hung browser installs at 100% download (zip completes, stream never closes) — deterministic, retries useless. Hit the #305 deploy at 14:08 and every CI run after. The hung deploy silently blocked the main deploy queue for 2.5h (deploy.yml queues, doesn't cancel) — deploys for #306/#307 got superseded while waiting. Fix: switched all CI to the runner's preinstalled Chrome (`channel: 'chrome'` when CI=true in playwright.config.ts + scripts/prerender.mjs), deleted browser download/cache steps from all 3 workflows. CI back to 2m30s. Docs updated in #308.
+
+**Gotcha:** `gh` CLI token intermittently 401'd on GraphQL/DELETE endpoints while REST reads worked — merge succeeded but branch delete failed; used `git push origin --delete` over SSH instead.

--- a/content/blog/2026-01-15-decap-cms-netlify-setup-guide.txt
+++ b/content/blog/2026-01-15-decap-cms-netlify-setup-guide.txt
@@ -2,7 +2,7 @@
 title: "Decap CMS with Netlify: Git Gateway, Build Hooks, and the Cloudflare Gotcha"
 date: 2026-01-15
 author: Claude
-description: "How to set up Decap CMS on a static site with Netlify Identity and Git Gateway. Includes the fix for a 405 error when using Cloudflare."
+description: "Setting up Decap CMS with Netlify Identity, Git Gateway, and build hooks — config.yml included — plus the fix for the 405 error behind Cloudflare."
 tags:
   - Web Dev
 category: Technical

--- a/docs/SEO_MEASUREMENT.md
+++ b/docs/SEO_MEASUREMENT.md
@@ -95,6 +95,20 @@ if (!isPageSpeedError(result)) {
 
 Google Search Console API provides search performance data: queries, impressions, clicks, CTR, and average position.
 
+### Where the data lives in this repo
+
+The weekly fetch (`scripts/fetch-search-console-data.js`, run by the daily
+analytics workflow) writes `docs/metrics/search-console-history.json` —
+**including `topQueries`** (the actual search terms, with per-query
+impressions/clicks/position). Use that file when tuning titles and meta
+descriptions for CTR.
+
+The copy published to the live site
+(`public/metrics/search-console-history.json`) is sanitized by
+`scripts/copy-metrics-to-public.js`, which strips `topQueries` so visitor
+search terms are never exposed publicly. Only `topPages` and summary stats
+ship to the browser.
+
 **Free**: Unlimited for verified site owners
 **Authentication**: OAuth 2.0 or Service Account
 

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -5,13 +5,24 @@
     <link>https://dylanbochman.com/blog</link>
     <description>Articles and insights on Site Reliability Engineering, Incident Management, DevOps, and System Reliability.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 30 Apr 2026 00:00:00 GMT</lastBuildDate>
+    <lastBuildDate>Mon, 25 May 2026 00:00:00 GMT</lastBuildDate>
     <atom:link href="https://dylanbochman.com/rss.xml" rel="self" type="application/rss+xml"/>
     <image>
       <url>https://dylanbochman.com/social-preview.png</url>
       <title>Dylan Bochman - Blog</title>
       <link>https://dylanbochman.com/blog</link>
     </image>
+    <item>
+      <title>The Indexing Audit That Found a Redirect Loop</title>
+      <link>https://dylanbochman.com/blog/2026-05-25-the-indexing-audit-that-found-a-redirect-loop</link>
+      <guid isPermaLink="true">https://dylanbochman.com/blog/2026-05-25-the-indexing-audit-that-found-a-redirect-loop</guid>
+      <description>Google Search Console reported seven flavors of indexing trouble. Fixing them led me to a Cloudflare setting that had been quietly disabling half of the site&apos;s HTTPS for months.</description>
+      <pubDate>Mon, 25 May 2026 00:00:00 GMT</pubDate>
+      <author>dylan@dylanbochman.com (Dylan &amp; Claude)</author>
+      <category>SRE</category>
+      <category>Security</category>
+      <category>Web Dev</category>
+    </item>
     <item>
       <title>Two Supply Chain Attacks in One Day</title>
       <link>https://dylanbochman.com/blog/2026-04-30-two-supply-chain-attacks-in-one-day</link>
@@ -146,7 +157,7 @@
       <title>Decap CMS with Netlify: Git Gateway, Build Hooks, and the Cloudflare Gotcha</title>
       <link>https://dylanbochman.com/blog/2026-01-15-decap-cms-netlify-setup-guide</link>
       <guid isPermaLink="true">https://dylanbochman.com/blog/2026-01-15-decap-cms-netlify-setup-guide</guid>
-      <description>How to set up Decap CMS on a static site with Netlify Identity and Git Gateway. Includes the fix for a 405 error when using Cloudflare.</description>
+      <description>Setting up Decap CMS with Netlify Identity, Git Gateway, and build hooks — config.yml included — plus the fix for the 405 error behind Cloudflare.</description>
       <pubDate>Thu, 15 Jan 2026 00:00:00 GMT</pubDate>
       <author>dylan@dylanbochman.com (Claude)</author>
       <category>Web Dev</category>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,78 +2,84 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://dylanbochman.com/</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/blog</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/runbook</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/slo-tool</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/statuspage-update</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/oncall-coverage</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/kanban</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/analytics</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/changelog</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/incident-command-diagrams</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/k8s-rightsizer</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://dylanbochman.com/projects/echonest</loc>
+    <lastmod>2026-06-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://dylanbochman.com/blog/2026-05-25-the-indexing-audit-that-found-a-redirect-loop</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -130,6 +130,23 @@ async function prerender() {
       // Wait for React to render (longer wait for polling routes since we don't wait for network)
       await page.waitForTimeout(routesWithPolling.includes(route) ? 2000 : 500);
 
+      // react-helmet appends its meta tags without removing the static ones
+      // from index.html, so pages end up with two description/og tags and
+      // crawlers take the first (the site-wide default). Where helmet rendered
+      // a tag (data-rh), drop the static duplicate so exactly one value ships.
+      await page.evaluate(() => {
+        for (const tag of document.head.querySelectorAll('meta[data-rh]')) {
+          const name = tag.getAttribute('name');
+          const property = tag.getAttribute('property');
+          const selector = name
+            ? `meta[name="${name}"]:not([data-rh])`
+            : property
+              ? `meta[property="${property}"]:not([data-rh])`
+              : null;
+          if (selector) document.head.querySelectorAll(selector).forEach((dup) => dup.remove());
+        }
+      });
+
       // Get the rendered HTML
       const html = await page.content();
 


### PR DESCRIPTION
## Problem

Every blog post shipped **two** `<meta name="description">` tags — the site-wide SRE bio (hardcoded in `index.html`) first, then the correct per-post one from react-helmet. Crawlers take the first, so the SERP snippet for every post was the homepage bio. Likely a major contributor to 0.42% CTR at avg position 7.5 (benchmark: 2–4%). `og:description`/`twitter:` tags had the same duplication, so social shares were wrong too.

## Fix

- **prerender.mjs**: before capturing HTML, remove static template meta tags whenever helmet rendered the same key (`data-rh`). Generic — covers description, og:*, twitter:* on every prerendered route.
- **Decap CMS post description**: retargeted to the dominant query cluster from private Search Console data ("decap cms hook netlify-build" + config.yml — ~98% of site impressions, ranking pos ~2–8 with 0 clicks). slop-guard: 84/100.
- **docs/SEO_MEASUREMENT.md**: documented that `docs/metrics/search-console-history.json` keeps `topQueries` for CTR work while the public copy strips them.

## Verification

- Built locally: every prerendered page has exactly one description tag; the Decap post carries the new snippet in meta/og/twitter
- rss.xml/sitemap.xml diffs are legitimate regeneration (new description + previously stale checked-in copy)
- 216 unit tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)