### PR TITLE
perf(analytics): median-of-3 Lighthouse sampling with visible spread

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,7 +27,9 @@ jobs:
   lighthouse:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Each page is audited 3x for a median (scripts/lighthouse-multi-page.mjs),
+    # so the audit phase runs ~3x longer than a single-run pass.
+    timeout-minutes: 20
     permissions:
       contents: write
       issues: write

--- a/scripts/lighthouse-multi-page.mjs
+++ b/scripts/lighthouse-multi-page.mjs
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { writeFileSync, mkdirSync, readFileSync } from 'fs';
-import { dirname } from 'path';
+import { writeFileSync, mkdirSync, readFileSync, copyFileSync, rmSync } from 'fs';
 
 const execAsync = promisify(exec);
 
 const BASE_URL = process.env.BASE_URL || 'https://dylanbochman.com';
+
+// Lighthouse scores from a single run swing 10-15 points on shared CI
+// hardware (CPU contention skews TBT and LCP most). Running each page a few
+// times and keeping the median run damps that noise. Override with
+// LIGHTHOUSE_RUNS=1 for a fast local check.
+const RUNS = Math.max(1, Number(process.env.LIGHTHOUSE_RUNS || 3));
 
 // Pages to test
 const PAGES = [
@@ -21,8 +26,6 @@ const PAGES = [
 ];
 
 async function runLighthouse(url, outputPath) {
-  console.log(`\n🔦 Running Lighthouse on ${url}...`);
-
   try {
     await execAsync(
       `npx lighthouse "${url}" --output=json --output-path="${outputPath}" --chrome-flags='--headless' --quiet`
@@ -34,18 +37,25 @@ async function runLighthouse(url, outputPath) {
   }
 }
 
-function extractScores(reportPath) {
+// Pull both the human-readable display values (for the dashboard) and the
+// raw numeric values (for median selection and spread) out of one report.
+function extractRun(reportPath) {
   try {
     const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+    const cat = report.categories || {};
+    const audits = report.audits || {};
     return {
-      performance: Math.round((report.categories?.performance?.score ?? 0) * 100),
-      accessibility: Math.round((report.categories?.accessibility?.score ?? 0) * 100),
-      seo: Math.round((report.categories?.seo?.score ?? 0) * 100),
-      bestPractices: Math.round((report.categories?.['best-practices']?.score ?? 0) * 100),
-      lcp: report.audits?.['largest-contentful-paint']?.displayValue || 'N/A',
-      fcp: report.audits?.['first-contentful-paint']?.displayValue || 'N/A',
-      cls: report.audits?.['cumulative-layout-shift']?.displayValue || 'N/A',
-      tbt: report.audits?.['total-blocking-time']?.displayValue || 'N/A'
+      performance: Math.round((cat.performance?.score ?? 0) * 100),
+      accessibility: Math.round((cat.accessibility?.score ?? 0) * 100),
+      seo: Math.round((cat.seo?.score ?? 0) * 100),
+      bestPractices: Math.round((cat['best-practices']?.score ?? 0) * 100),
+      lcp: audits['largest-contentful-paint']?.displayValue || 'N/A',
+      fcp: audits['first-contentful-paint']?.displayValue || 'N/A',
+      cls: audits['cumulative-layout-shift']?.displayValue || 'N/A',
+      tbt: audits['total-blocking-time']?.displayValue || 'N/A',
+      // numeric (ms) for selection + spread; null if the audit didn't run
+      lcpMs: audits['largest-contentful-paint']?.numericValue ?? null,
+      tbtMs: audits['total-blocking-time']?.numericValue ?? null
     };
   } catch (error) {
     console.error(`❌ Failed to read report:`, error.message);
@@ -53,61 +63,126 @@ function extractScores(reportPath) {
   }
 }
 
+function median(nums) {
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+// Pick a single representative run rather than synthesizing per-metric medians
+// (which would describe a run that never happened). The run whose performance
+// score is closest to the median is the headline-stable choice; ties break on
+// the run closest to the median LCP. With RUNS=3 this is simply the middle run.
+function pickRepresentativeIndex(runs) {
+  const medPerf = median(runs.map(r => r.performance));
+  const medLcp = median(runs.map(r => r.lcpMs ?? Infinity));
+
+  let bestIdx = 0;
+  let best = { perfDist: Infinity, lcpDist: Infinity };
+  runs.forEach((r, i) => {
+    const perfDist = Math.abs(r.performance - medPerf);
+    const lcpDist = Math.abs((r.lcpMs ?? Infinity) - medLcp);
+    if (perfDist < best.perfDist || (perfDist === best.perfDist && lcpDist < best.lcpDist)) {
+      bestIdx = i;
+      best = { perfDist, lcpDist };
+    }
+  });
+  return bestIdx;
+}
+
+async function auditPage(page, reportsDir) {
+  const canonicalPath = `${reportsDir}/lighthouse-${page.name}.json`;
+  const runs = [];
+  const runPaths = [];
+
+  for (let i = 0; i < RUNS; i++) {
+    const runPath = RUNS === 1 ? canonicalPath : `${reportsDir}/lighthouse-${page.name}-run${i + 1}.json`;
+    process.stdout.write(`\n🔦 ${page.name} (run ${i + 1}/${RUNS}) ${page.url} ... `);
+    const success = await runLighthouse(page.url, runPath);
+    if (!success) continue;
+    const run = extractRun(runPath);
+    if (!run) continue;
+    runs.push(run);
+    runPaths.push(runPath);
+    process.stdout.write(`perf ${run.performance}, lcp ${run.lcp}, tbt ${run.tbt}`);
+  }
+
+  if (runs.length === 0) {
+    console.log(`\n⚠️  ${page.name}: all runs failed`);
+    return null;
+  }
+
+  const repIdx = pickRepresentativeIndex(runs);
+  const rep = runs[repIdx];
+
+  // Keep the representative run's full report under the canonical name; drop
+  // the per-run temp files so only one report per page is committed.
+  if (RUNS > 1) {
+    copyFileSync(runPaths[repIdx], canonicalPath);
+    for (const p of runPaths) {
+      if (p !== canonicalPath) rmSync(p, { force: true });
+    }
+  }
+
+  const perfs = runs.map(r => r.performance);
+  const tbts = runs.map(r => r.tbtMs).filter(v => v != null);
+
+  console.log(`\n✅ ${page.name}: perf ${rep.performance} (median of ${runs.length}), lcp ${rep.lcp}`);
+
+  return {
+    page: page.name,
+    url: page.url,
+    performance: rep.performance,
+    accessibility: rep.accessibility,
+    seo: rep.seo,
+    bestPractices: rep.bestPractices,
+    lcp: rep.lcp,
+    fcp: rep.fcp,
+    cls: rep.cls,
+    tbt: rep.tbt,
+    // Sampling metadata: lets the dashboard show how noisy each number is
+    // instead of presenting one run as if it were precise.
+    runs: runs.length,
+    performanceRange: [Math.min(...perfs), Math.max(...perfs)],
+    tbtRangeMs: tbts.length ? [Math.round(Math.min(...tbts)), Math.round(Math.max(...tbts))] : null
+  };
+}
+
 async function main() {
   console.log('🚀 Starting multi-page Lighthouse audit...\n');
   console.log(`Base URL: ${BASE_URL}`);
-  console.log(`Testing ${PAGES.length} pages...\n`);
+  console.log(`Testing ${PAGES.length} pages, ${RUNS} run(s) each (median)...\n`);
 
-  // Create reports directory
   const reportsDir = 'lighthouse-reports';
   mkdirSync(reportsDir, { recursive: true });
 
   const results = [];
-
   for (const page of PAGES) {
-    const reportPath = `${reportsDir}/lighthouse-${page.name}.json`;
-    const success = await runLighthouse(page.url, reportPath);
-
-    if (success) {
-      const scores = extractScores(reportPath);
-      if (scores) {
-        results.push({
-          page: page.name,
-          url: page.url,
-          ...scores
-        });
-
-        console.log(`✅ ${page.name}:`);
-        console.log(`   Performance: ${scores.performance}`);
-        console.log(`   Accessibility: ${scores.accessibility}`);
-        console.log(`   SEO: ${scores.seo}`);
-        console.log(`   Best Practices: ${scores.bestPractices}`);
-        console.log(`   LCP: ${scores.lcp}, FCP: ${scores.fcp}`);
-      }
-    }
+    const result = await auditPage(page, reportsDir);
+    if (result) results.push(result);
   }
 
-  // Save summary
   const summaryPath = `${reportsDir}/summary.json`;
   writeFileSync(summaryPath, JSON.stringify(results, null, 2));
   console.log(`\n📊 Summary saved to ${summaryPath}`);
 
   // Print summary table
-  console.log('\n📋 Performance Summary:');
-  console.log('┌─────────────────┬──────┬──────┬─────┬───────┐');
-  console.log('│ Page            │ Perf │ A11y │ SEO │ Best  │');
-  console.log('├─────────────────┼──────┼──────┼─────┼───────┤');
+  console.log('\n📋 Performance Summary (median run):');
+  console.log('┌─────────────────┬──────┬─────────┬──────┬─────┬───────┐');
+  console.log('│ Page            │ Perf │ Range   │ A11y │ SEO │ Best  │');
+  console.log('├─────────────────┼──────┼─────────┼──────┼─────┼───────┤');
   results.forEach(r => {
     const page = r.page.padEnd(15);
     const perf = String(r.performance).padStart(4);
+    const range = `${r.performanceRange[0]}-${r.performanceRange[1]}`.padStart(7);
     const a11y = String(r.accessibility).padStart(4);
     const seo = String(r.seo).padStart(3);
     const best = String(r.bestPractices).padStart(5);
-    console.log(`│ ${page} │ ${perf} │ ${a11y} │ ${seo} │ ${best} │`);
+    console.log(`│ ${page} │ ${perf} │ ${range} │ ${a11y} │ ${seo} │ ${best} │`);
   });
-  console.log('└─────────────────┴──────┴──────┴─────┴───────┘');
+  console.log('└─────────────────┴──────┴─────────┴──────┴─────┴───────┘');
 
-  // Check for failures
+  // Check for failures (based on the representative run)
   const failures = results.filter(r =>
     r.performance < 50 || r.accessibility < 90 || r.seo < 90 || r.bestPractices < 90
   );

--- a/src/components/analytics/LighthouseScoresTable.tsx
+++ b/src/components/analytics/LighthouseScoresTable.tsx
@@ -71,6 +71,12 @@ export function LighthouseScoresTable({ data }: LighthouseScoresTableProps) {
                   </td>
                   <td className="text-center py-2">
                     <ScoreBadge score={page.performance} />
+                    {page.performanceRange &&
+                      page.performanceRange[0] !== page.performanceRange[1] && (
+                        <div className="text-[10px] text-muted-foreground tabular-nums mt-0.5">
+                          {page.performanceRange[0]}&ndash;{page.performanceRange[1]}
+                        </div>
+                      )}
                   </td>
                   <td className="text-center py-2">
                     <ScoreBadge score={page.accessibility} />

--- a/src/components/analytics/types.ts
+++ b/src/components/analytics/types.ts
@@ -129,6 +129,11 @@ export interface LighthousePageScore {
   fcp: string;
   cls: string;
   tbt: string;
+  // Sampling metadata (added when the audit runs multiple times and keeps the
+  // median). Optional so older summary.json files still parse.
+  runs?: number;
+  performanceRange?: [number, number];
+  tbtRangeMs?: [number, number] | null;
 }
 
 // GitHub Actions billing data types


### PR DESCRIPTION
## Problem

A single Lighthouse run on a shared GitHub Actions runner swings 10-15 points between back-to-back passes — CPU contention skews TBT and LCP most. That variance is how a single frozen homepage score of 95 stayed convincing for five months (see [The Dashboard That Measured January](https://dylanbochman.com/blog/2026-06-12-the-dashboard-that-measured-january) and [#311](https://github.com/Dbochman/personal-website/pull/311)). A live test against the same site, same code, scored home at **79 then 94 on consecutive runs**.

## Fix

- **Median sampling** — `scripts/lighthouse-multi-page.mjs` audits each page `RUNS` times (default 3, `LIGHTHOUSE_RUNS=1` for a fast local check) and keeps the **representative median run**: the run whose performance score is nearest the median, with LCP as tie-break. It picks a *real* run rather than synthesizing per-metric medians, which would describe a run that never happened. Per-run temp reports are cleaned up; the median run's full report is kept under the canonical name.
- **Visible spread** — `summary.json` gains `runs`, `performanceRange`, and `tbtRangeMs` (additive; optional in `LighthousePageScore` so older files still parse). The scores table renders the min–max performance range under each score, so the dashboard communicates noise instead of hiding it.
- **Timeout** — `lighthouse.yml` 10 → 20 min for the ~3× audit time.

## Trade-offs (intentional)

- ~3× the audit runtime. The job runs post-deploy and doesn't block deploys, so on free runners this is negligible.
- Median-of-3 damps variance but doesn't eliminate it; the root cause is shared-runner CPU. This is the cheap 80/20, not a dedicated-runner cure.

## Verification

- `tsc` clean, `eslint` clean, 216/216 tests pass.
- Median / LCP tie-break / single-run selection covered by synthetic unit tests.
- 2-run live pass across all 8 pages produced correct median picks, populated `performanceRange`/`tbtRangeMs`, and clean temp-file removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)